### PR TITLE
Add support for both http and https

### DIFF
--- a/code/boot.js
+++ b/code/boot.js
@@ -305,8 +305,8 @@ try { console.log('Loading included JS now'); } catch(e) {}
 
 try { console.log('done loading included JS'); } catch(e) {}
 
-var JQUERY = 'https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js';
-var JQUERYUI = 'https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js';
+var JQUERY = window.location.protocol + '//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js';
+var JQUERYUI = window.location.protocol + '//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.min.js';
 
 // after all scripts have loaded, boot the actual app
 load(JQUERY).then(JQUERYUI).thenRun(boot);

--- a/code/chat.js
+++ b/code/chat.js
@@ -279,7 +279,7 @@ window.chat.writeDataToHash = function(newData, storageHash, skipSecureMsgs) {
 
       case 'PORTAL':
         var latlng = [markup[1].latE6/1E6, markup[1].lngE6/1E6];
-        var perma = 'https://ingress.com/intel?latE6='+markup[1].latE6+'&lngE6='+markup[1].lngE6+'&z=17&pguid='+markup[1].guid;
+        var perma = window.location.protocol + '//ingress.com/intel?latE6='+markup[1].latE6+'&lngE6='+markup[1].lngE6+'&z=17&pguid='+markup[1].guid;
         var js = 'window.zoomToAndShowPortal(\''+markup[1].guid+'\', ['+latlng[0]+', '+latlng[1]+']);return false';
 
         msg += '<a onclick="'+js+'"'

--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -45,12 +45,12 @@ window.renderPortalDetails = function(guid) {
 
   setPortalIndicators(d);
   var img = d.imageByUrl && d.imageByUrl.imageUrl
-    ? d.imageByUrl.imageUrl.replace(/^http:/, 'https:')
+    ? d.imageByUrl.imageUrl.replace(/^http:/, window.location.protocol)
     : DEFAULT_PORTAL_IMG;
 
   var lat = d.locationE6.latE6;
   var lng = d.locationE6.lngE6;
-  var perma = 'https://ingress.com/intel?latE6='+lat+'&lngE6='+lng+'&z=17&pguid='+guid;
+  var perma = window.location.protocol + '//ingress.com/intel?latE6='+lat+'&lngE6='+lng+'&z=17&pguid='+guid;
   var imgTitle = 'title="'+getPortalDescriptionFromDetails(d)+'\n\nClick to show full image."';
   var poslinks = 'window.showPortalPosLinks('+lat/1E6+','+lng/1E6+')';
   var postcard = 'Send in a postcard. Will put it online after receiving. Address:\\n\\nStefan Breunig\\nINF 305 – R045\\n69120 Heidelberg\\nGermany';

--- a/code/utils_misc.js
+++ b/code/utils_misc.js
@@ -62,7 +62,7 @@ window.postAjax = function(action, data, success, error) {
     // use full URL to avoid issues depending on how people set their
     // slash. See:
     // https://github.com/breunigs/ingress-intel-total-conversion/issues/56
-    url: 'https://www.ingress.com/rpc/dashboard.'+action,
+    url: window.location.protocol + '//www.ingress.com/rpc/dashboard.'+action,
     type: 'POST',
     data: data,
     dataType: 'json',

--- a/main.js
+++ b/main.js
@@ -21,12 +21,6 @@ window.iitcBuildDate = '@@BUILDDATE@@';
 // disable vanilla JS
 window.onload = function() {};
 
-if(window.location.protocol !== 'https:') {
-  var redir = window.location.href.replace(/^http:/, 'https:');
-  window.location = redir;
-  throw('Need to load HTTPS version.');
-}
-
 // rescue user data from original page
 var scr = document.getElementsByTagName('script');
 for(var x in scr) {
@@ -172,7 +166,7 @@ window.RANGE_INDICATOR_COLOR = 'red'
 window.PORTAL_RADIUS_ENLARGE_MOBILE = 5;
 
 
-window.DEFAULT_PORTAL_IMG = 'https://commondatastorage.googleapis.com/ingress/img/default-portal-image.png';
+window.DEFAULT_PORTAL_IMG = window.location.protocol + '//commondatastorage.googleapis.com/ingress/img/default-portal-image.png';
 window.NOMINATIM = 'http://nominatim.openstreetmap.org/search?format=json&limit=1&q=';
 
 // INGRESS CONSTANTS /////////////////////////////////////////////////

--- a/plugins/compute-ap-stats.user.js
+++ b/plugins/compute-ap-stats.user.js
@@ -7,7 +7,9 @@
 // @downloadURL    https://raw.github.com/breunigs/ingress-intel-total-conversion/gh-pages/plugins/compute-ap-stats.user.js
 // @description    Tries to determine overal AP stats for the current zoom
 // @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
 // @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
 // ==/UserScript==
 
 function wrapper() {

--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -7,7 +7,9 @@
 // @downloadURL    https://raw.github.com/breunigs/ingress-intel-total-conversion/gh-pages/plugins/draw-tools.user.js
 // @description    Allows you to draw things into the current map so you may plan your next move
 // @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
 // @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
 // ==/UserScript==
 
 function wrapper() {

--- a/plugins/guess-player-levels.user.js
+++ b/plugins/guess-player-levels.user.js
@@ -7,7 +7,9 @@
 // @downloadURL    https://raw.github.com/breunigs/ingress-intel-total-conversion/gh-pages/plugins/guess-player-levels.user.js
 // @description    Tries to determine player levels from the data available in the current view
 // @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
 // @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
 // ==/UserScript==
 
 function wrapper() {

--- a/plugins/max-links.user.js
+++ b/plugins/max-links.user.js
@@ -6,7 +6,9 @@
 // @downloadURL    https://raw.github.com/breunigs/ingress-intel-total-conversion/gh-pages/plugins/max-links.user.js
 // @description    Calculates how to link the portals to create the maximum number of fields.
 // @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
 // @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
 // ==/UserScript==
 
 function wrapper() {

--- a/plugins/player-tracker.user.js
+++ b/plugins/player-tracker.user.js
@@ -7,7 +7,9 @@
 // @downloadURL    https://raw.github.com/breunigs/ingress-intel-total-conversion/gh-pages/plugins/player-tracker.user.js
 // @description    draws trails for the path a user went onto the map. Only draws the last hour. Does not request chat data on its own, even if that would be useful.
 // @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
 // @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
 // ==/UserScript==
 
 function wrapper() {

--- a/plugins/render-limit-increase.user.js
+++ b/plugins/render-limit-increase.user.js
@@ -7,7 +7,9 @@
 // @downloadURL    https://raw.github.com/breunigs/ingress-intel-total-conversion/gh-pages/plugins/render-limit-increase.user.js
 // @description    Increase the render limits, so less likely to be hit in higher density areas
 // @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
 // @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
 // ==/UserScript==
 
 function wrapper() {

--- a/plugins/reso-energy-pct-in-portal-detail.user.js
+++ b/plugins/reso-energy-pct-in-portal-detail.user.js
@@ -7,7 +7,9 @@
 // @downloadURL    https://raw.github.com/breunigs/ingress-intel-total-conversion/gh-pages/plugins/reso-energy-pct-in-portal-detail.user.js
 // @description    Show resonator energy percentage on resonator energy bar in portal detail panel.
 // @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
 // @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
 // ==/UserScript==
 
 function wrapper() {

--- a/plugins/resonator-display-zoom-level-decrease.user.js
+++ b/plugins/resonator-display-zoom-level-decrease.user.js
@@ -7,7 +7,9 @@
 // @downloadURL    https://raw.github.com/breunigs/ingress-intel-total-conversion/gh-pages/plugins/resonator-display-zoom-level-decrease.user.js
 // @description    Resonator start display earlier
 // @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
 // @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
 // ==/UserScript==
 
 function wrapper() {

--- a/plugins/show-address.user.js
+++ b/plugins/show-address.user.js
@@ -7,7 +7,9 @@
 // @downloadURL    https://raw.github.com/breunigs/ingress-intel-total-conversion/gh-pages/plugins/show-address.user.js
 // @description    Portal address will show in the sidebar.
 // @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
 // @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
 // ==/UserScript==
 
 function wrapper() {

--- a/plugins/show-portal-weakness.user.js
+++ b/plugins/show-portal-weakness.user.js
@@ -7,7 +7,9 @@
 // @downloadURL    https://raw.github.com/breunigs/ingress-intel-total-conversion/gh-pages/plugins/show-portal-weakness.user.js
 // @description    Uses the fill color of the portals to denote if the portal is weak (Needs recharging, missing a resonator, needs shields)  Red, needs energy and shields. Orange, only needs energy (either recharge or resonators). Yellow, only needs shields.
 // @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
 // @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
 // ==/UserScript==
 
 function wrapper() {


### PR DESCRIPTION
remove automatic http to https redirect

use window.location.protocol rather than assuming https in several locations

plugins @include + @match cover both https and http

some things remain as https - but at least https items in a http page doesn't produce browser warnings, unlike http items in a https page
