### PR TITLE
Display Portal Level on AP List

### DIFF
--- a/plugins/ap-list.user.js
+++ b/plugins/ap-list.user.js
@@ -155,7 +155,7 @@ window.plugin.apList.getPortalLink = function(portal) {
   var a = $('<a>',{
     "class": 'help',
     style: style,
-    text: portal.portalV2.descriptiveText.TITLE + ' (' + Math.round(window.getPortalLevel(portal)*10)/10 + ')',
+    text: portal.portalV2.descriptiveText.TITLE + ' (L' + Math.floor(window.getPortalLevel(portal)) + ')',
     title: portal.portalV2.descriptiveText.ADDRESS,
     href: perma,
     onClick: jsSingleClick,


### PR DESCRIPTION
Being able to see portal level is important for anyone who is not L7-8 (like me) in order to evaluate if those high AP targets are worth pursuing.
