### PR TITLE
Build: add a modified index.php script to outdir (+ additional build setting) 

### DIFF
--- a/build.py
+++ b/build.py
@@ -51,6 +51,8 @@ dateTimeVersion = time.strftime('%Y%m%d.%H%M%S',utcTime)
 resourceUrlBase = settings['resourceUrlBase']
 distUrlBase = settings['distUrlBase']
 
+# new setting, so add a default
+includePage = settings.get('includePage', False)
 
 
 def readfile(fn):
@@ -140,5 +142,11 @@ for fn in glob.glob("plugins/*.user.js"):
     metafn = fn.replace('.user.js', '.meta.js')
     saveScriptAndMeta(script, os.path.join(outDir,fn), os.path.join(outDir,metafn))
 
+if includePage:
+    page = 'index.php'
+    page_content = readfile(os.path.join('website', page))
+    page_content = page_content.replace('$path = "release";', '$path = ".";')
+    with io.open(os.path.join(outDir, page), 'w', encoding='utf8') as f:
+        f.write(page_content)
 
 # vim: ai si ts=4 sw=4 sts=4 et

--- a/buildsettings.py
+++ b/buildsettings.py
@@ -8,6 +8,7 @@ buildSettings = {
     'local': {
         'resourceUrlBase': 'http://iitc.jonatkins.com/release',
         'distUrlBase': None,
+        'includePage': False,
     },
 
     # local8000: if you need to modify external resources, this build will load them from
@@ -15,6 +16,7 @@ buildSettings = {
     'local8000': {
         'resourceUrlBase': 'http://0.0.0.0:8000/dist',
         'distUrlBase': None,
+        'includePage': False,
     },
 
 
@@ -24,6 +26,7 @@ buildSettings = {
     #'example': {
     #    'resourceBaseUrl': 'http://www.example.com/iitc/dist',
     #    'distUrlBase': 'https://secure.example.com/iitc/dist',
+    #    'includePage': True,
     #},
 
 


### PR DESCRIPTION
To make installing from user specified locations easier, include the
index.php file in the final folder .
