### PR TITLE
Build in default marker icon images

### DIFF
--- a/code/boot.js
+++ b/code/boot.js
@@ -320,14 +320,12 @@ function boot() {
   if(window.deviceID) console.log('Your device ID: ' + window.deviceID);
   window.runOnSmartphonesBeforeBoot();
 
-  // overwrite default Leaflet Marker icon to be a neutral color
-  var base = '@@RESOURCEURLBASE@@/images';
-  L.Icon.Default.imagePath = base;
-
   var iconEnlImage = '@@INCLUDEIMAGE:images/marker-green.png@@';
   var iconEnlRetImage = '@@INCLUDEIMAGE:images/marker-green_2x.png@@';
   var iconResImage = '@@INCLUDEIMAGE:images/marker-blue.png@@';
   var iconResRetImage = '@@INCLUDEIMAGE:images/marker-blue_2x.png@@';
+  var iconDefImage = '@@INCLUDEIMAGE:images/marker-icon.png@@';
+  var iconDefRetImage = '@@INCLUDEIMAGE:images/marker-icon_2x.png@@';
   var iconShadowImage = '@@INCLUDEIMAGE:images/marker-shadow.png@@';
 
   window.iconEnl = L.Icon.extend({options: {
@@ -343,6 +341,16 @@ function boot() {
   window.iconRes = L.Icon.extend({options: {
     iconUrl: iconResImage,
     iconRetinaUrl: iconResRetImage,
+    shadowUrl: iconShadowImage,
+    shadowRetinaUrl: iconShadowImage,
+    iconSize: new L.Point(25, 41),
+    iconAnchor: new L.Point(12, 41),
+    popupAnchor: new L.Point(1, -34),
+    shadowSize: new L.Point(41, 41)
+  }});
+  L.Icon.Default = L.Icon.extend({options: {
+    iconUrl: iconDefImage,
+    iconRetinaUrl: iconDefRetImage,
     shadowUrl: iconShadowImage,
     shadowRetinaUrl: iconShadowImage,
     iconSize: new L.Point(25, 41),


### PR DESCRIPTION
More clean up on things that had external dependencies.  Draw tools uses the default marker icon so we should have it built in. #5 #48
