### PR TITLE
Privacy view plugin

### DIFF
--- a/plugins/privacy-view.user.js
+++ b/plugins/privacy-view.user.js
@@ -1,9 +1,9 @@
 // ==UserScript==
 // @id             iitc-plugin-privacy-view@Scrool
 // @name           IITC plugin: Privacy view on Intel
-// @version        1.0.@@DATETIMEVERSION@@
+// @version        1.0.0.@@DATETIMEVERSION@@
 // @namespace      https://github.com/jonatkins/ingress-intel-total-conversion
-// @description    From Intel hides info which shouldn't leak to players of other fraction
+// @description    [@@BUILDNAME@@-@@BUILDDATE@@] From Intel hides info which shouldn't leak to players of other fraction
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @include        https://www.ingress.com/intel*


### PR DESCRIPTION
Hides info which shouldn't leak to players of the other fraction. This can be used in shared environment - e.g. work, outside to safely display intel map.

Adds button on the top of chat to switch between modes. If it is active, hides chat elements on the left bottom and player name with level on the top right.
