### PR TITLE
Bugfix to ipas-link plugin for the case of missing resonators on the portal

### DIFF
--- a/plugins/ipas-link.user.js
+++ b/plugins/ipas-link.user.js
@@ -33,7 +33,12 @@ window.plugin.ipasLink.addLink = function(d) {
 window.plugin.ipasLink.getHash = function(d) {
     var hashParts=[];
     $.each(d.resonatorArray.resonators, function(ind, reso) {
-        hashParts.push(reso.level + "," + reso.distanceToPortal + "," + reso.energyTotal);
+        if ($reso) {
+            hashParts.push(reso.level + "," + reso.distanceToPortal + "," + reso.energyTotal);
+        } else {
+            hashParts.push(1 + "," + 35 + "," + 0); // Dummy values, the only important one is energy=0
+        }
+    }
     });
     return hashParts.join(";")+"|" + "0,0,0,0"; //shields not implemented yet
 }


### PR DESCRIPTION
Adds dummy values to the hash, with energyTotal=0 for that resonator
