### PR TITLE
Change portal image urls to https if necessary in the portal object

### DIFF
--- a/code/map_data.js
+++ b/code/map_data.js
@@ -105,7 +105,15 @@ window.handleDataResponse = function(data, textStatus, jqXHR) {
               && urlPortal !== ent[0]
           ) return;
 
-
+        if('imageByUrl' in ent[2] && 'imageUrl' in ent[2].imageByUrl) {
+          if(window.location.protocol === 'https:') {
+            ent[2].imageByUrl.imageUrl = ent[2].imageByUrl.imageUrl.indexOf('www.panoramio.com') !== -1
+                                       ? ent[2].imageByUrl.imageUrl.replace(/^http:\/\/www/, 'https://ssl').replace('small', 'medium')
+                                       : ent[2].imageByUrl.imageUrl.replace(/^http:\/\//, '//');
+          }
+        } else {
+          ent[2].imageByUrl = {'imageUrl': DEFAULT_PORTAL_IMG};
+        }
 
         ppp.push(ent); // delay portal render
       } else if(ent[2].edge !== undefined) {

--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -44,10 +44,7 @@ window.renderPortalDetails = function(guid) {
   var resoDetails = '<table id="resodetails">' + getResonatorDetails(d) + '</table>';
 
   setPortalIndicators(d);
-  var img = d.imageByUrl && d.imageByUrl.imageUrl
-    ? d.imageByUrl.imageUrl
-    : DEFAULT_PORTAL_IMG;
-
+  var img = d.imageByUrl.imageUrl;
   var lat = d.locationE6.latE6;
   var lng = d.locationE6.lngE6;
   var perma = '/intel?latE6='+lat+'&lngE6='+lng+'&z=17&pguid='+guid;


### PR DESCRIPTION
Addresses #126 and does this all in one spot.  No need for plugins or anything else using images to need to check for no image and do a default replacement.
