### PR TITLE
Added player's resonators plugin

### DIFF
--- a/plugins/players-resonators.user.js
+++ b/plugins/players-resonators.user.js
@@ -71,7 +71,7 @@ window.plugin.playersResonators.findReso = function(playername) {
     fakeLinkPlayer = '<a href="#" onClick="return false;">' + effectiveNick + '</a>'
     s = fakeLinkPlayer + " has resonators on these portals:\n\n" + s;  
   } else {
-    s = fakeLinkPlayer + " has no resonators in this range\n";  
+    s = playername + " has no resonators in this range\n";  
   }
   alert(s);
 }


### PR DESCRIPTION
I wrote a plugin that shows all the portals having a resonator by a specified player in an alert box, with clickable names (that zoom on the portal) and mouseover for portal address.
The input is from and input field on the sidebar, like "Redeem code".
This is my first pull request so let me know if I'm doing all right.
