### PR TITLE
Reduced render limit on mobile.

### DIFF
--- a/code/smartphone.js
+++ b/code/smartphone.js
@@ -95,4 +95,10 @@ window.runOnSmartphonesAfterBoot = function() {
       });
     });
   });
+
+  // Force lower render limits for mobile
+  window.VIEWPORT_PAD_RATIO = 0.1;
+  window.MAX_DRAWN_PORTALS = 500;
+  window.MAX_DRAWN_LINKS = 200;
+  window.MAX_DRAWN_FIELDS = 100;
 }


### PR DESCRIPTION
Ideally this would be done via a Settings dialog but until someone gets a chance to design and implement such a thing this is a quick hack to try and prevent crashing the mobile browser/app.
