### PR TITLE
mobile: Use cache on Android 4.1+ if using Wi-Fi tethering.

### DIFF
--- a/mobile/src/com/cradle/iitc_mobile/IITC_WebView.java
+++ b/mobile/src/com/cradle/iitc_mobile/IITC_WebView.java
@@ -130,7 +130,7 @@ public class IITC_WebView extends WebView {
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo wifi = conMan.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            return wifi.getState() == NetworkInfo.State.CONNECTED && conMan.isActiveNetworkMetered();
+            return wifi.getState() == NetworkInfo.State.CONNECTED && !conMan.isActiveNetworkMetered();
         }
         return wifi.getState() == NetworkInfo.State.CONNECTED;
     }


### PR DESCRIPTION
At least that's what I hope this does as it will hopefully save me some data when tethered with my Nexus 7.
