### PR TITLE
Add "!" to old shields

### DIFF
--- a/plugins/portals-list.user.js
+++ b/plugins/portals-list.user.js
@@ -137,6 +137,11 @@ window.plugin.portalslist.getPortals = function() {
         if (modShortName === '') {
             mods[ind] = ['', '', ''];
             } else {
+		if ((modShortName === 'S') &&
+		((mod.rarity=='COMMON' && mod.stats.MITIGATION == 6) || 
+		(mod.rarity=='RARE' && mod.stats.MITIGATION == 8) ||
+		(mod.rarity=='VERY_RARE' && mod.stats.MITIGATION == 10)))
+			modShortName=modShortName+'!';
 			mods[ind] = [mod.rarity, getPlayerName(mod.installingUser), modShortName, mod.displayName];            
         }
       }else { mods[ind] = ['', '', '']; }


### PR DESCRIPTION
Show old shields on portals with exclamation mark.
The old series of shields had mitigation values of 6, 8 and 10 (now it's 10, 20 and 30).

A preview of the list, the obsolete shields have "S!".
![image](https://f.cloud.github.com/assets/219708/841919/61764186-f3a1-11e2-9555-d5cef0f52ad7.png)
Maybe it would be useful to find some better style to highlight the old mods.
