### PR TITLE
Also allow meta click on nickname for player tracker to support os x

### DIFF
--- a/plugins/player-tracker.user.js
+++ b/plugins/player-tracker.user.js
@@ -382,7 +382,7 @@ window.plugin.playerTracker.centerMapOnUser = function(nick) {
 }
 
 window.plugin.playerTracker.onNicknameClicked = function(info) {
-  if (info.event.ctrlKey) {
+  if (info.event.ctrlKey || info.event.metaKey) {
     plugin.playerTracker.centerMapOnUser(info.nickname);
     return false;
   }


### PR DESCRIPTION
Control + Click is a "right click" on os x - so support meta click on player name to goto user for os x
