### PR TITLE
A plugin showing potentially linkable portals

### DIFF
--- a/website/page/code/desktop-download.php
+++ b/website/page/code/desktop-download.php
@@ -45,7 +45,6 @@ function iitcDesktopPluginDownloadTable ( $build )
 	$categories = Array (
 		'Portal Info' => "Enhanced information on the selected portal",
 		'Info' => "Display additional information",
-		'Inventory' => "Inventory sync and management",
 		'Keys' => "Manual key management",
 		'Controls' => "Map controls/widgets",
 		'Highlighter' => "Portal highlighters",


### PR DESCRIPTION
Potentially linkable means:
- If the player has a key + portal if of the right faction + has 8 resonators: linkable (marked red)
- If the player has a key but (portal if of the wrong faction or has < 8 resonators): might be linkable in future (marked orange).
  This is very useful when planning fields.
