### PR TITLE
Plugin - Data Freezer

### DIFF
--- a/plugins/data-freezer.user.js
+++ b/plugins/data-freezer.user.js
@@ -6,7 +6,7 @@
 // @namespace      https://github.com/jonatkins/ingress-intel-total-conversion
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
-// @description    [@@BUILDNAME@@-@@BUILDDATE@@] Disable automatic portal data refresh.
+// @description    [@@BUILDNAME@@-@@BUILDDATE@@] Disables the automatic data refresh.
 // @include        https://www.ingress.com/intel*
 // @include        http://www.ingress.com/intel*
 // @match          https://www.ingress.com/intel*


### PR DESCRIPTION
Disables the automatic data refresh (#441).
- Restores the last state;
- "map: paused" in the status bar when the data are freezed;
