### PR TITLE
Always show "sign out" link in IITCm.

### DIFF
--- a/code/boot.js
+++ b/code/boot.js
@@ -300,12 +300,6 @@ window.setupPlayerStat = function() {
     + '</div>'
     + '</h2>'
   );
-
-  $('#name').mouseenter(function() {
-    $('#signout').show();
-  }).mouseleave(function() {
-    $('#signout').hide();
-  });
 }
 
 window.setupSidebarToggle = function() {

--- a/mobile/smartphone.css
+++ b/mobile/smartphone.css
@@ -76,6 +76,10 @@ body {
   background-color: #00c5ff !important;
 }
 
+#name #signout { /* no hover, always show signout button */
+  display: block;
+}
+
 #sidebar, #chatcontrols, #chat, #chatinput {
   background: #0B3351 !important;
 }

--- a/style.css
+++ b/style.css
@@ -399,7 +399,7 @@ h2 #stats {
   overflow: hidden;
 }
 
-h2 #signout {
+#signout {
   font-size: 12px;
   font-weight: normal;
   line-height: 29px;
@@ -409,6 +409,9 @@ h2 #signout {
   right: 0;
   background-color: rgba(8, 48, 78, 0.5);
   display: none; /* starts hidden */
+}
+#name:hover #signout {
+  display: block;
 }
 
 h2 sup, h2 sub {


### PR DESCRIPTION
On smartphones, there is no mouse cursor, there hovering something is impossible.

Currently, the signout button is shown when hovering the player name. On mobile, this causes a problem. When you click the area where the signout button would be, it is first handled as a virtual mouseover, causing the button to appear. Then, the click event is applied, which leads to a signout, even though the user clicked an empty area.

This patch removes the JS that shows/hides the button, replacing the functionality with CSS. Also, a smartphone only snippet makes the button always visible.
