### PR TITLE
Added initial version of Effective Deployment Range highlighter.

### DIFF
--- a/plugins/portal-highlighter-bad-deployment-distance.user.js
+++ b/plugins/portal-highlighter-bad-deployment-distance.user.js
@@ -24,9 +24,8 @@ window.plugin.portalHighlighterBadDeploymentDistance = function() {};
 window.plugin.portalHighlighterBadDeploymentDistance.highlight = function(data) {
   var d = data.portal.options.details;
   var portal_deployment = 0;
-  var acceptable_deployment_average = 36;
   if(getTeam(d) !== 0) {
-    if(window.getAvgResoDist(d) > 0 && window.getAvgResoDist(d) < acceptable_deployment_average) {
+    if(window.getAvgResoDist(d) > 0 && window.getAvgResoDist(d) < window.HACK_RANGE*0.9) {
       portal_deployment = (window.HACK_RANGE - window.getAvgResoDist(d))/window.HACK_RANGE;
     }
     if(portal_deployment > 0) {


### PR DESCRIPTION
Highlights weakly-deployed portals by using the portal fill colour. The weaker the deployment, the darker red the portal appears. Useful for identifying weak targets, or for identifying weakly-deployed friendly portals that should be allowed to decay, for example.
