### PR TITLE
New Highlighter: Outbound Link Counter

### DIFF
--- a/plugins/portal-highlighter-outbound-link-counter.user.js
+++ b/plugins/portal-highlighter-outbound-link-counter.user.js
@@ -27,9 +27,9 @@ window.plugin.portalHighlighterOutboundLinkCounter.highlight = function(data) {
   var playerFaction = 0;
 
   if (window.PLAYER.team === 'RESISTANCE') {
-    playerFaction = 1;
+    playerFaction = window.TEAM_RES;
   } else {
-    playerFaction = 2;
+    playerFaction = window.TEAM_ENL;
   }
 
   // Only interested in portals of player's faction


### PR DESCRIPTION
To prevent those annoying occasions when I run out of outbound links from a portal... uses the fill colour of the portals to show the number of outbound links: red = 8 (i.e. no more outbound links may be made), orange = 6 or 7, yellow = 4 or 5. 
