### PR TITLE
Update Plugin AP List

### DIFF
--- a/plugins/ap-list.user.js
+++ b/plugins/ap-list.user.js
@@ -268,7 +268,9 @@ window.plugin.apList.updateSortedPortals = function() {
     var cachedPortal = oldcachedPortal[key];
     // If portal is changed, update playerApGain with latest
     // information
-    if(!cachedPortal || value.timestamp !== cachedPortal.timestamp) {
+    if(!cachedPortal
+        || value.timestamp !== cachedPortal.timestamp
+        || plugin.apList.isFieldsChanged(portal.portalV2.linkedFields, cachedPortal.portalV2.linkedFields)) {
       // Shallow copy portal detail to cachedPortal
       cachedPortal = $.extend({}, portal);
       var side = plugin.apList.portalSide(portal);
@@ -372,6 +374,11 @@ window.plugin.apList.updateTotalPages = function() {
     plugin.apList.totalPage[side] = Math.max(Math.ceil(portals.length / plugin.apList.portalPerPage), 1);
     plugin.apList.currentPage[side] = Math.min(plugin.apList.totalPage[side], plugin.apList.currentPage[side]);
   });
+}
+
+window.plugin.apList.isFieldsChanged = function(a,b) {
+  // http://stackoverflow.com/questions/1773069/using-jquery-to-compare-two-arrays
+  return $(a).not(b).get().length === 0 && $(b).not(a).get().length === 0;;
 }
 
 window.plugin.apList.portalSide = function(portal) {


### PR DESCRIPTION
1. Use `timestamp` to check update of portal data.
2. Change entry hook to `mapDataRefreshEnd`.

For the issue of shallow copy, there is already a deep copy on line 357 before modify the data in portalV2. 
`var newPortal = $.extend(true, {}, portal);`
So it won't modify original data and should be OK.
