### PR TITLE
window.playerNameToGuid: check cachedGuid !== null before return the cachedGuid

### DIFF
--- a/code/player_names.js
+++ b/code/player_names.js
@@ -37,7 +37,7 @@ window._playerNameToGuidCache = {};
 
 window.playerNameToGuid = function(playerName) {
   var cachedGuid = window._playerNameToGuidCache[playerName];
-  if (cachedGuid !== undefined) return cachedGuid;
+  if (cachedGuid !== undefined && cachedGuid !== null) return cachedGuid;
 
   var guid = null;
   $.each(Object.keys(sessionStorage), function(ind,key) {


### PR DESCRIPTION
Sometimes it store a null value and didn't get update even sessionStorage has a guid for that player.
