### PR TITLE
Add numbering to portals list

### DIFF
--- a/plugins/portals-list.user.js
+++ b/plugins/portals-list.user.js
@@ -195,7 +195,7 @@ window.plugin.portalslist.displayPL = function() {
     dialogClass: 'ui-dialog-portalslist',
     title: 'Portal list: ' + window.plugin.portalslist.listPortals.length + ' ' + (window.plugin.portalslist.listPortals.length == 1 ? 'portal' : 'portals'),
     id: 'portal-list',
-    width: 800
+    width: 830
   });
 
   // Setup sorting


### PR DESCRIPTION
1. Added numbering to the portals-list.user.js. Useful when you whant to determine how many portals we have above certain criteria after sorting (e.g. How many portals older that 20 days on map when sorting by Age).
2. Increased portals-list dialog width to 830px.  Now we have enough width to fit line width with number 9999.
