### PR TITLE
Add portal highlight plugin to highlight portals a comma separated list of L8 players can upgrade to level 8.

### DIFF
--- a/plugins/portal-highlighter-make8s.user.js
+++ b/plugins/portal-highlighter-make8s.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @id             iitc-plugin-highlight-portals-make8s-portals@bdh
+// @id             iitc-plugin-highlight-portals-make8s-portals@vanbhills
 // @name           IITC plugin: highlight portals a group of 8s can make 8
 // @category       Highlighter
 // @version        0.1.0.@@DATETIMEVERSION@@


### PR DESCRIPTION
Please consider adding this portal highlighter, it allows you to provide a comma delimited list of players who are assumed to be L8 and highlights portals they can upgrade to level 8 taking into consideration who is already deployed.

Thanks
