### PR TITLE
compatibility with Python 2.6

### DIFF
--- a/build.py
+++ b/build.py
@@ -112,7 +112,7 @@ def loaderRaw(var):
 def loaderMD(var):
     fn = var.group(1)
     # use different MD.dat's for python 2 vs 3 incase user switches versions, as they are not compatible
-    db = shelve.open('build/MDv' + str(sys.version_info.major) + '.dat')
+    db = shelve.open('build/MDv' + str(sys.version_info[0]) + '.dat')
     if 'files' in db:
       files = db['files']
     else:


### PR DESCRIPTION
Don't ask me why, but my system still has Python 2.6.

The `.major` notation has been added in [2.7](http://docs.python.org/2/library/sys.html#sys.version_info) and since everything works just fine with this small change, maybe it's worth having it.
