### PR TITLE
Don't add on click events on dialog open

### DIFF
--- a/plugins/portals-list.user.js
+++ b/plugins/portals-list.user.js
@@ -198,20 +198,6 @@ window.plugin.portalslist.displayPL = function() {
     width: 800
   });
 
-  // Setup sorting
-  $(document).on('click.portalslist', '#portalslist table th', function() {
-    $('#portalslist').html(window.plugin.portalslist.portalTable($(this).data('sort'),window.plugin.portalslist.sortOrder,window.plugin.portalslist.filter));
-  });
-  $(document).on('click.portalslist', '#portalslist .filterAll', function() {
-    $('#portalslist').html(window.plugin.portalslist.portalTable($(this).data('sort'),window.plugin.portalslist.sortOrder,0));
-  });
-  $(document).on('click.portalslist', '#portalslist .filterRes', function() {
-    $('#portalslist').html(window.plugin.portalslist.portalTable($(this).data('sort'),window.plugin.portalslist.sortOrder,1));
-  });
-  $(document).on('click.portalslist', '#portalslist .filterEnl', function() {
-    $('#portalslist').html(window.plugin.portalslist.portalTable($(this).data('sort'),window.plugin.portalslist.sortOrder,2));
-  });
-
   //run the name resolving process
   resolvePlayerNames();
   
@@ -447,6 +433,19 @@ var setup =  function() {
     '#portalslist .disclaimer { margin-top: 10px; font-size:10px; }' +
     '#portalslist .portalTitle { display: inline-block; width: 160px !important; min-width: 160px !important; max-width: 160px !important; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }' +
     '</style>');
+  // Setup sorting
+  $(document).on('click.portalslist', '#portalslist table th', function() {
+    $('#portalslist').html(window.plugin.portalslist.portalTable($(this).data('sort'),window.plugin.portalslist.sortOrder,window.plugin.portalslist.filter));
+  });
+  $(document).on('click.portalslist', '#portalslist .filterAll', function() {
+    $('#portalslist').html(window.plugin.portalslist.portalTable($(this).data('sort'),window.plugin.portalslist.sortOrder,0));
+  });
+  $(document).on('click.portalslist', '#portalslist .filterRes', function() {
+    $('#portalslist').html(window.plugin.portalslist.portalTable($(this).data('sort'),window.plugin.portalslist.sortOrder,1));
+  });
+  $(document).on('click.portalslist', '#portalslist .filterEnl', function() {
+    $('#portalslist').html(window.plugin.portalslist.portalTable($(this).data('sort'),window.plugin.portalslist.sortOrder,2));
+  });
 }
 
 // PLUGIN END //////////////////////////////////////////////////////////

--- a/plugins/scoreboard.user.js
+++ b/plugins/scoreboard.user.js
@@ -287,11 +287,6 @@ window.plugin.scoreboard.display = function() {
     id: 'scoreboard'
   });
 
-  // Setup sorting
-  $(document).on('click', '#players table th', function() {
-    $('#players').html(window.plugin.scoreboard.playerTable($(this).data('sort')));
-  });
-
   //run the name resolving process
   resolvePlayerNames();
 }
@@ -334,6 +329,10 @@ var setup =  function() {
     '.mu_score span.res { background-color: #005684; text-align: right; padding-right:4px; }' +
     '.mu_score span.enl { background-color: #017f01; padding-left: 4px; }' +
     '</style>');
+  // Setup sorting
+  $(document).on('click', '#players table th', function() {
+    $('#players').html(window.plugin.scoreboard.playerTable($(this).data('sort')));
+  });
 }
 
 // PLUGIN END //////////////////////////////////////////////////////////


### PR DESCRIPTION
Instead add them once during setup

This fixes an issue where click events would fire x amount of times
depending on how many times the dialog was opened and closed, on even
times sort would run twice and not toggle.
