### PR TITLE
Fix guess-player-levels

### DIFF
--- a/plugins/guess-player-levels.user.js
+++ b/plugins/guess-player-levels.user.js
@@ -159,15 +159,17 @@ window.plugin.guessPlayerLevels.guess = function() {
           playersRes[nick] = lvl;
       });
 
-      var nick = details.captured.capturingPlayerId
-      if(isSystemPlayer(nick)) return true;
-      var lvl = window.plugin.guessPlayerLevels.fetchLevelByPlayer(nick);
-      if(!lvl) return true;
+      if(details.captured) {
+        var nick = details.captured.capturingPlayerId
+        if(isSystemPlayer(nick)) return true;
+        var lvl = window.plugin.guessPlayerLevels.fetchLevelByPlayer(nick);
+        if(!lvl) return true;
 
-      if(getTeam(details) === TEAM_ENL)
-        playersEnl[nick] = lvl;
-      else
-        playersRes[nick] = lvl;
+        if(getTeam(details) === TEAM_ENL)
+          playersEnl[nick] = lvl;
+        else
+          playersRes[nick] = lvl;
+      }
     }
   });
 


### PR DESCRIPTION
Should work now.

Bonus feature: all levels are cache in memory to reduce calls to localStorage.

If you want, you can merge now, or you give me a bit more time to make it look for deploy messages in COMM.
