### PR TITLE
guess-player-levels

### DIFF
--- a/plugins/guess-player-levels.user.js
+++ b/plugins/guess-player-levels.user.js
@@ -2,7 +2,7 @@
 // @id             iitc-plugin-guess-player-levels@breunigs
 // @name           IITC plugin: guess player level
 // @category       Info
-// @version        0.4.10.@@DATETIMEVERSION@@
+// @version        0.5.0.@@DATETIMEVERSION@@
 // @namespace      https://github.com/jonatkins/ingress-intel-total-conversion
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@

--- a/plugins/player-tracker.user.js
+++ b/plugins/player-tracker.user.js
@@ -2,7 +2,7 @@
 // @id             iitc-plugin-player-tracker@breunigs
 // @name           IITC Plugin: Player tracker
 // @category       Layer
-// @version        0.10.1.@@DATETIMEVERSION@@
+// @version        0.10.2.@@DATETIMEVERSION@@
 // @namespace      https://github.com/jonatkins/ingress-intel-total-conversion
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@


### PR DESCRIPTION
- use public COMM data to find player levels
- distinguish guess levels (from deployed resonators) and guaranteed levels (from COMM data)
