### PR TITLE
fix for calculating AP gain including field count

### DIFF
--- a/code/portal_detail.js
+++ b/code/portal_detail.js
@@ -32,6 +32,7 @@ window.portalDetail.isFresh = function(guid) {
 var handleResponse = function(guid, data, success) {
 
   if (success) {
+    data.guid = guid;
     cache.store(guid,data);
 
     //FIXME..? better way of handling sidebar refreshing...

--- a/code/portal_info.js
+++ b/code/portal_info.js
@@ -124,9 +124,7 @@ window.getAttackApGain = function(d) {
 
   var linkCount = d.portalV2.linkedEdges ? d.portalV2.linkedEdges.length : 0;
 
-//FIXME: portalV2.linkedFields was never a piece of data from the server - it was something faked in IITC
-//with the portal guid, window.getPortalFields will return the count of linked fields - but no guid passed into here
-  var fieldCount = d.portalV2.linkedFields ? d.portalV2.linkedFields.length : 0;
+  var fieldCount = window.getPortalFields(d.guid).length;
 
   var resoAp = resoCount * DESTROY_RESONATOR;
   var linkAp = linkCount * DESTROY_LINK;


### PR DESCRIPTION
adding the guid to the portal details dataset (stored in cache) allows functions which get the detail dataset directly (such as window.getAttackApGain) to access the guid
Fixes issue #671 
