### PR TITLE
Return to old user experience of clicking on portal link replaces

### DIFF
--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -109,7 +109,7 @@ window.renderPortalDetails = function(guid) {
 
   } else {
     // non-android - a permalink for the portal
-    var permaHtml = $('<div>').html( $('<a>').attr({href:permalinkUrl, target:'_blank', title:'Create a URL link to this portal'}).text('Portal link') ).html();
+    var permaHtml = $('<div>').html( $('<a>').attr({href:permalinkUrl, title:'Create a URL link to this portal'}).text('Portal link') ).html();
     linkDetails.push ( '<aside>'+permaHtml+'</aside>' );
 
     // and a map link popup dialog


### PR DESCRIPTION
current page.

Rationale: Users have several options of opening a link in a new
tab/window without the target, whereas with the target, users have no
option of reusing the same window.
