### PR TITLE
Fix the calculation for Link Amp range boost to be generic, so VRLA boos...

### DIFF
--- a/code/portal_info.js
+++ b/code/portal_info.js
@@ -68,22 +68,22 @@ window.getLinkAmpRangeBoost = function(d) {
   // (at the time of writing, only rare link amps have been seen in the wild, so there's a little guesswork at how
   // the stats work and combine - jon 2013-06-26)
 
-  // link amps scale: first is full, second half, the last two a quarter
-  var scale = [1.0, 0.5, 0.25, 0.25];
+  // link amps scale: first is full, second a quarter, the last two an eigth
+  var scale = [1.0, 0.25, 0.125, 0.125];
 
-  var boost = 1.0;  // initial boost is 1.0 (i.e. no boost over standard range)
+  var boost = 0.0;  // initial boost is 0.0 (i.e. no boost over standard range)
   var count = 0;
 
   $.each(d.portalV2.linkedModArray, function(ind, mod) {
     if(mod && mod.type === 'LINK_AMPLIFIER' && mod.stats && mod.stats.LINK_RANGE_MULTIPLIER) {
       // link amp stat LINK_RANGE_MULTIPLIER is 2000 for rare, and gives 2x boost to the range
       var baseMultiplier = mod.stats.LINK_RANGE_MULTIPLIER/1000;
-      boost += (baseMultiplier-1)*scale[count];
+      boost += baseMultiplier*scale[count];
       count++;
     }
   });
 
-  return boost;
+  return (count > 0) ? boost : 1.0;
 }
 
 


### PR DESCRIPTION
...ts are correctly calculated.

For RLA, the first multiplier is 2x. Subsequent RLAs add 0.5, 0.25, 0.25 to the multiplier. But expressed as a fraction of the initial multiplier, this is 0.25, 0.125, 0.125. Scale array has been updated to reflect this. This means the "-1" in the calculation is no longer required, and that boost is correctly calculated when baseMultiplier is anything other than 2 (eg VRLA, when it is 7).
If there aren't any Link Amps, the multiplier is 1x.

Related to #688
