### PR TITLE
Check for null host in shouldInterceptRequest to prevent FCs

### DIFF
--- a/mobile/src/com/cradle/iitc_mobile/IITC_WebViewClient.java
+++ b/mobile/src/com/cradle/iitc_mobile/IITC_WebViewClient.java
@@ -147,7 +147,7 @@ public class IITC_WebViewClient extends WebViewClient {
         }
 
         Uri uri = Uri.parse(url);
-        if (uri.getHost().endsWith(DOMAIN) &&
+        if (uri.getHost()!=null && uri.getHost().endsWith(DOMAIN) &&
                 ("http".equals(uri.getScheme()) || "https".equals(uri.getScheme())))
             return mIitc.getFileManager().getResponse(uri);
 


### PR DESCRIPTION
base64 encoded image resources were causing .getHost() to return null and then a NullPointerException when .endswith was called on line 150
