### PR TITLE
Add support for property "style" to geoJson.

### DIFF
--- a/external/leaflet.filelayer.js
+++ b/external/leaflet.filelayer.js
@@ -44,7 +44,11 @@ var FileLoader = L.Class.extend({
         if (typeof content == 'string') {
             content = JSON.parse(content);
         }
-        return L.geoJson(content, this.options.layerOptions).addTo(this._map);
+        return L.geoJson(content, {
+            style: function (feature) {
+                return feature.properties && feature.properties.style;
+            }
+        }).addTo(this._map);
     },
 
     _convertToGeoJSON: function (content, format) {


### PR DESCRIPTION
SVG CSS styles can be used to style geoJson features.
Nice feature for planning larger projects (e.g. crossfaction "link-art").

Example:

{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {
        "style": {
          "weight": 2,
          "color": "#999",
          "opacity": 1,
          "fillColor": "#B0DE5C",
          "fillOpacity": 0.8
        }
      },
      "geometry": {
        "type": "MultiPolygon",
        "coordinates": [
          [
            [
              [48.00432014465332, 14.74732195489861],
              [48.00715255737305, 14.74620006835170],
              [48.00921249389647, 14.74468219277038],
              [48.01067161560059, 14.74362625960105],
              [48.01195907592773, 14.74290029616054],
              [48.00989913940431, 14.74078835902781],
              [48.00758171081543, 14.74059036160317],
              [48.00346183776855, 14.74059036160317],
              [48.00097274780272, 14.74059036160317],
              [48.00062942504881, 14.74072235994946],
              [48.00020027160645, 14.74191033368865],
              [48.00071525573731, 14.74276830198601],
              [48.00097274780272, 14.74369225589818],
              [48.00097274780272, 14.74461619742136],
              [48.00123023986816, 14.74534214278395],
              [48.00183105468751, 14.74613407445653],
              [48.00432014465332, 14.74732195489861]
            ],[
              [48.00361204147337, 14.74354376414072],
              [48.00301122665405, 14.74278480127163],
              [48.00221729278564, 14.74316428375108],
              [48.00283956527711, 14.74390674342741],
              [48.00361204147337, 14.74354376414072]
            ]
          ],[
            [
              [48.00942707061768, 14.73989736613708],
              [48.00942707061768, 14.73910536278566],
              [48.00685214996338, 14.73923736397631],
              [48.00384807586671, 14.73910536278566],
              [48.00174522399902, 14.73903936209552],
              [48.00041484832764, 14.73910536278566],
              [48.00041484832764, 14.73979836621592],
              [48.00535011291504, 14.73986436617916],
              [48.00942707061768, 14.73989736613708]
            ]
          ]
        ]
      }
    }
  ]
}
