### PR TITLE
Add-KML plugin support for IITC Mobile

### DIFF
--- a/mobile/src/com/cradle/iitc_mobile/IITC_JSInterface.java
+++ b/mobile/src/com/cradle/iitc_mobile/IITC_JSInterface.java
@@ -224,4 +224,9 @@ public class IITC_JSInterface {
             }
         });
     }
+    
+    @JavascriptInterface
+    public void pickKMLFile() {
+    	mIitc.onOpenKmlFile();
+     }
 }

--- a/plugins/add-kml.user.js
+++ b/plugins/add-kml.user.js
@@ -26,6 +26,61 @@ window.plugin.overlayKML.loadExternals = function() {
   @@INCLUDERAW:external/leaflet.filelayer.js@@
   try { console.log('done loading leaflet.filelayer JS'); } catch(e) {}
 
+  if (typeof android !== 'undefined' && android && android.pickKMLFile) {
+    try { console.log('Loading android webview extensions for leaflet.filelayer JS now'); } catch(e) {}
+    var FileLoaderMixin = {
+      parse: function (fileContent, fileName) {
+        // Check file extension
+        var ext = fileName.split('.').pop(),
+          parser = this._parsers[ext];
+        if (!parser) {
+          window.alert("Unsupported file type " + file.type + '(' + ext + ')');
+          return;
+        }
+        this.fire('data:loading', {filename: fileName, format: ext});
+        var layer = parser.call(this, fileContent, ext);
+        this.fire('data:loaded', {layer: layer, filename: fileName, format: ext});
+      }
+    };
+    FileLoader.include(FileLoaderMixin);
+
+    var FileLayerLoadMixin = {
+      getLoader: function () {
+        return this.loader;
+      },
+      _initContainer: function () {
+        // Create a button, and bind click on hidden file input
+        var zoomName = 'leaflet-control-filelayer leaflet-control-zoom',
+          barName = 'leaflet-bar',
+          partName = barName + '-part',
+          container = L.DomUtil.create('div', zoomName + ' ' + barName);
+        var link = L.DomUtil.create('a', zoomName + '-in ' + partName, container);
+        link.innerHTML = L.Control.FileLayerLoad.LABEL;
+        link.href = '#';
+        link.title = L.Control.FileLayerLoad.TITLE;
+
+        var stop = L.DomEvent.stopPropagation;
+        L.DomEvent
+          .on(link, 'click', stop)
+          .on(link, 'mousedown', stop)
+          .on(link, 'dblclick', stop)
+          .on(link, 'click', L.DomEvent.preventDefault)
+          .on(link, 'click', function (e) {
+            android.pickKMLFile();
+            e.preventDefault();
+          });
+        return container;
+      }
+    };
+    L.Control.FileLayerLoad.include(FileLayerLoadMixin);
+
+    window.plugin.overlayKML.addKML = function(fileContent, fileName) {
+      _fileLayerLoad.getLoader().parse(atob(fileContent), fileName);
+    }
+
+    try { console.log('done loading android webview extensions for leaflet.filelayer JS'); } catch(e) {}
+  }
+
   try { console.log('Loading KML JS now'); } catch(e) {}
   @@INCLUDERAW:external/KML.js@@
   try { console.log('done loading KML JS'); } catch(e) {}
@@ -36,6 +91,8 @@ window.plugin.overlayKML.loadExternals = function() {
 
   window.plugin.overlayKML.load();
 }
+
+var _fileLayerLoad = null;
 
 window.plugin.overlayKML.load = function() {
   // Provide popup window allow user to select KML to overlay
@@ -50,13 +107,14 @@ window.plugin.overlayKML.load = function() {
   });
   
   L.Control.FileLayerLoad.LABEL = '<img src="@@INCLUDEIMAGE:images/open-folder-icon_sml.png@@" alt="Open" />';
-  L.Control.fileLayerLoad({
+  _fileLayerLoad = L.Control.fileLayerLoad({
     fitBounds: true,
     layerOptions: {
       pointToLayer: function (data, latlng) {
       return L.marker(latlng, {icon: KMLIcon});
     }},
-  }).addTo(map);
+  });
+  _fileLayerLoad.addTo(map);
 }
 
 var setup =  function() {


### PR DESCRIPTION
Currently Add-KML plugin does not work in IITC Mobile, as HTML file input is not supported by Android webview, but the plugin depends on HTML file input to pick a KML/geoJSON/GPX file to open.

To support add-KML in IITC Mobile I added a pickKmlFile method to IITC_JSInterface which starts a file chooser intent, reads the selected file and passes the content of the selected file back to the method addKml in the javascript of the add-kml plugin.
