### PR TITLE
regions.user.js: add 50% transparency to label

### DIFF
--- a/plugins/regions.user.js
+++ b/plugins/regions.user.js
@@ -35,6 +35,7 @@ window.plugin.regions.setup  = function() {
              font-size: 14px;\
              font-weight: bold;\
              color: gold;\
+             opacity: 0.5; \
              text-align: center;\
              text-shadow: -1px -1px #000, 1px -1px #000, -1px 1px #000, 1px 1px #000, 0 0 2px #000; \
              pointer-events: none;\


### PR DESCRIPTION
I think without any transparency the region labels are a bit "harsh", this makes them look much nicer.
