### PR TITLE
fixed broken kml support

### DIFF
--- a/external/leaflet.filelayer.js
+++ b/external/leaflet.filelayer.js
@@ -44,13 +44,13 @@ var FileLoader = L.Class.extend({
         if (typeof content == 'string') {
             content = JSON.parse(content);
         }
-        return L.geoJson(content, {
+        return L.geoJson(content, L.Util.extend({}, this.options.layerOptions, {
             style: function (feature) {
                 return feature.properties && feature.properties.style;
             }
-        }).addTo(this._map);
+        })).addTo(this._map);
     },
-
+	
     _convertToGeoJSON: function (content, format) {
         // Format is either 'gpx' or 'kml'
         if (typeof content == 'string') {


### PR DESCRIPTION
@leCradle pointed out that commit a172b288da7a4fb5f76c11a751d34d8bdfc43ced (https://github.com/jonatkins/ingress-intel-total-conversion/commit/a172b288da7a4fb5f76c11a751d34d8bdfc43ced) broke support for kml files

This patch restores the original kml support, but still keeps styling support for geojson
