### PR TITLE
Fixed Issue in Draw Tool: Buttons had an ugly line break

### DIFF
--- a/external/leaflet.draw.css
+++ b/external/leaflet.draw.css
@@ -50,6 +50,7 @@
 	position: absolute;
 	left: 26px; /* leaflet-draw-toolbar.left + leaflet-draw-toolbar.width */
 	top: 0;
+	white-space: nowrap;
 }
 
 .leaflet-right .leaflet-draw-actions {
@@ -98,7 +99,6 @@
 
 .leaflet-draw-actions-top {
 	margin-top: 1px;
-	white-space: nowrap;
 }
 
 .leaflet-draw-actions-top a,


### PR DESCRIPTION
fixed line break between save/cancel for delete layers. 

After the "edit layers" Button, the "save" and "cancel" buttons are appearing in one row.
After the "delete layers" Button, they dont, they break line, what obviously (rounded right-border at last button) isnt supposed to do so.
This small CSS change fixes this issue.
