### PR TITLE
guess-player-levels - do not handle incomplete portal details

### DIFF
--- a/plugins/guess-player-levels.user.js
+++ b/plugins/guess-player-levels.user.js
@@ -119,7 +119,7 @@ window.plugin.guessPlayerLevels.setupChatNickHelper = function() {
 }
 
 window.plugin.guessPlayerLevels.extractPortalData = function(data) {
-  if(!data.success) return;
+  if(!data.success || !data.details.portalV2) return;
 
   var r = data.details.resonatorArray.resonators;
 


### PR DESCRIPTION
Server returns an empty details object for invalid/deleted portals.
plugin would hang attempting to get resonatorArray of undefined.
