### PR TITLE
build.py: loaderString should escape \-characters?

### DIFF
--- a/build.py
+++ b/build.py
@@ -103,7 +103,7 @@ def readfile(fn):
 
 def loaderString(var):
     fn = var.group(1)
-    return readfile(fn).replace('\n', '\\n').replace('\'', '\\\'')
+    return readfile(fn).replace('\\', '\\\\').replace('\n', '\\n').replace('\'', '\\\'')
 
 def loaderRaw(var):
     fn = var.group(1)


### PR DESCRIPTION
I have almost no experience in python, but I think loaderString should escape backslash-charaters.

I dit a quick test with a file  with 3 lines, where the first and last line are empty and the middle line contained the string "\n".

When importing this file with @@INCLUDESTRING:@@ the generated file contained the string "\n\n\n", which is obviously wrong, because that would be 4 empty lines. After adding the .replace('\', '\\') the string was "\n\n\n" which should be the correct behaviour in my opinion.
