### PR TITLE
Removing html tags from portal description before html entities are enco...

### DIFF
--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -76,7 +76,7 @@ window.renderPortalDetails = function(guid) {
 // can make reading the description difficult. Use jQuery's text() function to
 // remove these first, then encode any html entitites that remain.
     if(portalDetailObj.description) {
-      portalDetailedDescription += '<tr class="padding-top"><th>Description:</th><td>' + escapeHtmlSpecialChars($(portalDetailObj.description).text()) + '</td></tr>';
+      portalDetailedDescription += '<tr class="padding-top"><th>Description:</th><td>' + escapeHtmlSpecialChars($('<div>' + portalDetailObj.description).text() + '</div>') + '</td></tr>';
     }
 //    if(d.descriptiveText.map.ADDRESS) {
 //      portalDetailedDescription += '<tr><th>Address:</th><td>' + escapeHtmlSpecialChars(d.descriptiveText.map.ADDRESS) + '</td></tr>';


### PR DESCRIPTION
Simple one line change (if you ignore the comment). The portals that were pulled in by Niantic occasionally include HTML tags that make reading the description painful. This change is just to send the portal description through jQuery's text() function. Any remaining HTML entities are encoded as before.

Example portal that shows the issue in the portal description.
http://www.ingress.com/intel?ll=35.595636,-75.467904&z=17&pll=35.595636,-75.467904

Before (snippet):
Description:    &lt;center&gt;&lt;b&gt;The Chicamacomico Races&lt;/b&gt;&lt;/center&gt;&lt;br&gt; Soon after the capture of Hatteras Inlet, 

After change (snippet):
Description:    The Chicamacomico Races Soon after the capture of Hatteras Inlet, 
