### PR TITLE
Added portal description to mobile info window.

### DIFF
--- a/code/smartphone.js
+++ b/code/smartphone.js
@@ -62,6 +62,15 @@ window.runOnSmartphonesBeforeBoot = function() {
     } else {
       x.addClass('fullimg').appendTo('#sidebar');
     }
+
+    $('#mobileDesc').remove();
+    var details = portalDetail.get(data.guid);
+    var portalDetailObj = details ? window.getPortalDescriptionFromDetailsExtended(data.portalDetails) : undefined;
+    if (portalDetailObj.description) {
+        var t = '<div id="mobileDesc"><table description="Portal Photo Details" class="portal_details">';
+        t += '<tr class="padding-top"><th>Description:</th><td>' + escapeHtmlSpecialChars($('<div>' + portalDetailObj.description + '</div>').text()) + '</td></tr></table></div>';
+        $(t).appendTo('#sidebar');
+    }
   });
 }
 


### PR DESCRIPTION
With the mobile version, I noticed there is no way to open the portal details dialog. The sidebar is populated with all of the normal information. It also has the full size image which would normally go in the dialog, but it does not get the portal description.

I've added in the description below the full size image if the portal has a description. The HTML tags are also stripped from this description before any remaining HTML entities get encoded.

I'll see if there was an issue raised for this problem. 
