### PR TITLE
Remove CHAT_MIN_RANGE

### DIFF
--- a/code/chat.js
+++ b/code/chat.js
@@ -41,9 +41,7 @@ window.chat._oldBBox = null;
 window.chat.genPostData = function(isFaction, storageHash, getOlderMsgs) {
   if(typeof isFaction !== 'boolean') throw('Need to know if public or faction chat.');
 
-  // get window bounds, and extend to the minimum chat radius
-  chat._localRangeCircle.setLatLng(map.getCenter());
-  var b = map.getBounds().extend(chat._localRangeCircle.getBounds());
+  var b = map.getBounds();
 
   // set a current bounding box if none set so far
   if (!chat._oldBBox) chat._oldBBox = b;
@@ -574,8 +572,6 @@ window.chat.keepScrollPosition = function(box, scrollBefore, isOldMsgs) {
 //
 
 window.chat.setup = function() {
-  window.chat._localRangeCircle =  L.circle(map.getCenter(), CHAT_MIN_RANGE*1000);
-
   if (localStorage['iitc-chat-tab']) {
     var t = $('<a>'+localStorage['iitc-chat-tab']+'</a>');
     window.chat.chooseAnchor(t);

--- a/main.js
+++ b/main.js
@@ -142,10 +142,6 @@ window.MAX_IDLE_TIME = 4*60; // stop updating map after 4min idling
 window.PRECACHE_PLAYER_NAMES_ZOOM = 17; // zoom level to start pre-resolving player names
 window.HIDDEN_SCROLLBAR_ASSUMED_WIDTH = 20;
 window.SIDEBAR_WIDTH = 300;
-// chat messages are requested for the visible viewport. On high zoom
-// levels this gets pretty pointless, so request messages in at least a
-// X km radius.
-window.CHAT_MIN_RANGE = 6;
 // this controls how far data is being drawn outside the viewport. Set
 // it 0 to only draw entities that intersect the current view. A value
 // of one will render an area twice the size of the viewport (or some-


### PR DESCRIPTION
...or at least make it optional.

According to main.js:

``` js
// chat messages are requested for the visible viewport. On high zoom
// levels this gets pretty pointless, so request messages in at least a
// X km radius.
window.CHAT_MIN_RANGE = 6;
```

Actually, it isn't completely pointless. Sometimes I zoom very close to a specific portal because I only want logs for this portal. I've heard similar reports from other people as well. It happen to me that I wondered why the log contained entries for portals far away, as I didn't think of this range.

I want to discuss this here before making sudden changes.
