### PR TITLE
Fix typos in plugin descriptions

### DIFF
--- a/plugins/portal-highlighter-forgotten.user.js
+++ b/plugins/portal-highlighter-forgotten.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @id             iitc-plugin-highlight-forgotten@jonatkins
-// @name           IITC plugin: Inactive portals. Hightlight unclaimed portals with no recent activity
+// @name           IITC plugin: Inactive portals. Highlight unclaimed portals with no recent activity
 // @category       Highlighter
 // @version        0.1.0.@@DATETIMEVERSION@@
 // @namespace      https://github.com/jonatkins/ingress-intel-total-conversion

--- a/plugins/portal-highlighter-needs-recharge.user.js
+++ b/plugins/portal-highlighter-needs-recharge.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @id             iitc-plugin-highlight-needs-recharge@vita10gy
-// @name           IITC plugin: hightlight portals that need recharging
+// @name           IITC plugin: highlight portals that need recharging
 // @category       Highlighter
 // @version        0.1.1.@@DATETIMEVERSION@@
 // @namespace      https://github.com/jonatkins/ingress-intel-total-conversion


### PR DESCRIPTION
"Highlight" was misspelled as "hightlight".
