### PR TITLE
[uniques] Re-enable COMM parsing, since position-to-guid cache used now

### DIFF
--- a/plugins/uniques.user.js
+++ b/plugins/uniques.user.js
@@ -503,7 +503,7 @@ var setup = function() {
 	window.plugin.uniques.setupContent();
 	window.plugin.uniques.loadLocal('uniques');
 	window.addHook('portalDetailsUpdated', window.plugin.uniques.onPortalDetailsUpdated);
-	//window.addHook('publicChatDataAvailable', window.plugin.uniques.onPublicChatDataAvailable);
+	window.addHook('publicChatDataAvailable', window.plugin.uniques.onPublicChatDataAvailable);
 	window.addHook('iitcLoaded', window.plugin.uniques.registerFieldForSyncing);
 		window.addPortalHighlighter('Uniques', window.plugin.uniques.highlighter);
 


### PR DESCRIPTION
This fixes the issue with the uniques plugin COMM parsing not getting re-enabled after the position cache was added. 

Reported in https://plus.google.com/114307153172689842498/posts/BYkGr5qAhWJ
