### PR TITLE
#896: Ensure updateMap calls endCompoundOperation

### DIFF
--- a/plugins/sync.user.js
+++ b/plugins/sync.user.js
@@ -119,19 +119,24 @@ window.plugin.sync.RegisteredMap.prototype.updateMap = function(keyArray) {
   var _this = this;
   // Use compound operation to ensure update pushed as a batch
   this.model.beginCompoundOperation();
-  // Remove before set text to ensure full text change
-  this.lastUpdateUUID.removeRange(0, this.lastUpdateUUID.length);
-  this.lastUpdateUUID.setText(this.uuid);
-
-  $.each(keyArray, function(ind, key) {
-    var value = window.plugin[_this.pluginName][_this.fieldName][key];
-    if(typeof(value) !== 'undefined') {
-      _this.map.set(key, value);
-    } else {
-      _this.map.delete(key);
-    }
-  });
-  this.model.endCompoundOperation();
+  try {
+    // Remove before set text to ensure full text change
+    if (this.lastUpdateUUID.length > 0)
+      this.lastUpdateUUID.removeRange(0, this.lastUpdateUUID.length);
+    this.lastUpdateUUID.setText(this.uuid);
+  
+    $.each(keyArray, function(ind, key) {
+      var value = window.plugin[_this.pluginName][_this.fieldName][key];
+      if(typeof(value) !== 'undefined') {
+        _this.map.set(key, value);
+      } else {
+        _this.map.delete(key);
+      }
+    });
+  } finally {
+    // Ensure endCompoundOperation is always called (see bug #896)
+    this.model.endCompoundOperation();
+  }
 }
 
 window.plugin.sync.RegisteredMap.prototype.isUpdatedByOthers = function() {


### PR DESCRIPTION
Ensure endCompoundOperation is called whenever beginCompoundOperation completes, even if removeRange (or anything in the range) fails. Moreover, call `removeRange` only when there is text to remove, since apparently the realtime API complains otherwise.

This is a quick hack — I tested locally "essentially the same changes" done with TamperMonkey, and it appears to work well.
