### PR TITLE
Fix spelling error in Draw Tools plugin

### DIFF
--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -386,7 +386,7 @@ window.plugin.drawTools.optPaste = function() {
       var data = JSON.parse(promptAction);
       window.plugin.drawTools.drawnItems.clearLayers();
       window.plugin.drawTools.import(data);
-      console.log('DRAWTOOLS: reset and imported drawn tiems');
+      console.log('DRAWTOOLS: reset and imported drawn items');
       window.plugin.drawTools.optAlert('Import Successful.');
 
       // to write back the data to localStorage


### PR DESCRIPTION
There is a minor spelling error in a log message in the draw tools plugin function optPaste(). This pull request corrects the typo.
