### PR TITLE
Use dialog() consistently to only allow one instance of each dialog to b...

### DIFF
--- a/code/artifact.js
+++ b/code/artifact.js
@@ -328,6 +328,7 @@ window.artifact.showArtifactList = function() {
 
   dialog({
     title: 'Artifacts',
+    id: 'iitc-artifacts',
     html: html,
     width: 400,
     position: {my: 'right center', at: 'center-60 center', of: window, collision: 'fit'}

--- a/code/boot.js
+++ b/code/boot.js
@@ -9,16 +9,23 @@ window.setupLargeImagePreview = function() {
     var details = $(this).find('div.portalDetails')[0];
     //dialogs have 12px padding around the content
     var dlgWidth = Math.max(img.naturalWidth+24,500);
+    // This might be a case where multiple dialogs make sense, for example
+    // someone might want to compare images of multiple portals.  But
+    // usually we only want to show one version of each image.
+    // To support that, we'd need a unique key per portal.  Example, guid.
+    // So that would have to be in the html fetched into details.
     if (details) {
       dialog({
         html: '<div style="text-align: center">' + img.outerHTML + '</div>' + details.outerHTML,
         title: $(this).parent().find('h3.title').text(),
+        id: 'iitc-portal-image',
         width: dlgWidth,
       });
     } else {
       dialog({
         html: '<div style="text-align: center">' + img.outerHTML + '</div>',
         title: $(this).parent().find('h3.title').text(),
+        id: 'iitc-portal-image',
         width: dlgWidth,
       });
     }

--- a/code/utils_misc.js
+++ b/code/utils_misc.js
@@ -60,6 +60,7 @@ window.aboutIITC = function() {
 
   dialog({
     title: 'IITC ' + v,
+    id: 'iitc-about',
     html: a,
     dialogClass: 'ui-dialog-aboutIITC'
   });

--- a/plugins/bookmarks-by-zaso.user.js
+++ b/plugins/bookmarks-by-zaso.user.js
@@ -451,6 +451,7 @@
     dialog({
       html: window.plugin.bookmarks.dialogLoadListFolders('bookmarksDialogMobileSort', 'window.plugin.bookmarks.mobileSort', true, type),
       dialogClass: 'ui-dialog-bkmrksSet-copy',
+      id: 'plugin-bookmarks-move-bookmark',
       title: 'Bookmarks - Move Bookmark'
     });
   }
@@ -560,6 +561,7 @@
     dialog({
       html: plugin.bookmarks.htmlSetbox,
       dialogClass: 'ui-dialog-bkmrksSet',
+      id: 'plugin-bookmarks-options',
       title: 'Bookmarks Options'
     });
 
@@ -578,6 +580,7 @@
       dialog({
         html: '<p><a onclick="$(\'.ui-dialog-bkmrksSet-copy textarea\').select();">Select all</a> and press CTRL+C to copy it.</p><textarea readonly>'+localStorage[window.plugin.bookmarks.KEY_STORAGE]+'</textarea>',
         dialogClass: 'ui-dialog-bkmrksSet-copy',
+        id: 'plugin-bookmarks-export',
         title: 'Bookmarks Export'
       });
     }
@@ -723,6 +726,7 @@
     dialog({
       html: window.plugin.bookmarks.dialogLoadListFolders('bookmarksDialogRenameF', 'window.plugin.bookmarks.renameFolder', false, 0),
       dialogClass: 'ui-dialog-bkmrksSet-copy',
+      id: 'plugin-bookmarks-rename-folder',
       title: 'Bookmarks Rename Folder'
     });
   }
@@ -734,6 +738,7 @@
     dialog({
       html:window.plugin.bookmarks.dialogLoadList,
       dialogClass:'ui-dialog-autodrawer',
+      id: 'plugin-bookmarks-move-bookmark',
       title:'Bookmarks - Auto Draw',
       buttons:{
         'DRAW': function() {

--- a/plugins/canvas-render.user.js
+++ b/plugins/canvas-render.user.js
@@ -36,6 +36,7 @@ window.plugin.canvasRendering.setup  = function() {
   if (!L.Path.CANVAS) {
     dialog({
       title:'Canvas Render Warning',
+      id:'plugin-canvas-render-warning',
       text:'The Canvas Rendering plugin failed to enable canvas rendering in leaflet. This will occur if it initialises too late.\n'
           +'Try re-ordering userscripts so Canvas Rendering is before the main IITC script.'
     });

--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -335,6 +335,7 @@ window.plugin.drawTools.manualOpt = function() {
   dialog({
     html: html,
     dialogClass: 'ui-dialog-drawtoolsSet',
+    id: 'plugin-drawtools-options',
     title: 'Draw Tools Options'
   });
 
@@ -368,6 +369,7 @@ window.plugin.drawTools.optCopy = function() {
         html: '<p><a onclick="$(\'.ui-dialog-drawtoolsSet-copy textarea\').select();">Select all</a> and press CTRL+C to copy it.</p><textarea readonly onclick="$(\'.ui-dialog-drawtoolsSet-copy textarea\').select();">'+localStorage['plugin-draw-tools-layer']+'</textarea>',
         width: 600,
         dialogClass: 'ui-dialog-drawtoolsSet-copy',
+        id: 'plugin-drawtools-export',
         title: 'Draw Tools Export'
         });
     }

--- a/plugins/portal-counts.user.js
+++ b/plugins/portal-counts.user.js
@@ -199,6 +199,7 @@ window.plugin.portalcounts.getPortals = function (){
     dialog({
       html: '<div id="portalcounts">' + counts + '</div>',
       title: 'Portal counts: ' + title,
+      id: 'plugin-portal-counts',
       width: 'auto'
     });
   }

--- a/plugins/update-check.user.js
+++ b/plugins/update-check.user.js
@@ -288,6 +288,7 @@ window.plugin.updateCheck.showReport = function(data) {
   dialog({
     width: 700,
     title: 'Update check',
+    id: 'plugin-update-check',
     html: result
   });
 }


### PR DESCRIPTION
...e

open.

Some dialogs, like DrawTools Opt, don't work properly when multiple
instances are open.  Most others simply do not make sense.
