### PR TITLE
Don't do ajax lookup when search is lat/lng cords

### DIFF
--- a/code/geosearch.js
+++ b/code/geosearch.js
@@ -22,6 +22,18 @@ window.search = function(search) {
       return true;
     }
     
+    if(search.split(",").length == 2) {
+      var ll = search.split(",");
+      if(!isNaN(ll[0]) && !isNaN(ll[1])) {
+        ll = [parseFloat(ll[0]), parseFloat(ll[1])];
+        if(ll[0] >= -90 && ll[0] <= 90 && ll[1] >= -180 && ll[1] <= 180) {
+          window.map.setView(L.latLng(ll[0], ll[1]), 17);
+          if(window.isSmartphone()) window.show('map');
+          return true;
+        }
+      }
+    }
+
     $.getJSON(NOMINATIM + encodeURIComponent(search), function(data) {
       if(!data || !data[0]) {
         $('#geosearch').addClass('search_not_found');      


### PR DESCRIPTION
I've heard of a couple of cases of people dropping a latitude and longitude coordinate pair into the search box and not ending up centered on exactly where they expected, some farther off than others.  It looks to me like the geocoder finds the closest poi to the coordinates then returns the bounds for that.  We don't even need to ask the geocoder to look up a coordinate pair, we can just center the map on it and be done.