### PR TITLE
Added Plugin to remove portal resizing

### DIFF
--- a/plugins/portal-highlighter-no-resize.user.js
+++ b/plugins/portal-highlighter-no-resize.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @id             iitc-plugin-highlight-no-resize@spontifixus
+// @id             iitc-plugin-highlight-no-resize@Luciolinox
 // @name           IITC plugin: Remove Portal Resizing
 // @category       Highlighter
 // @version        0.1.0.@@DATETIMEVERSION@@

--- a/plugins/portal-highlighter-no-resize.user.js
+++ b/plugins/portal-highlighter-no-resize.user.js
@@ -1,0 +1,39 @@
+// ==UserScript==
+// @id             iitc-plugin-highlight-no-resize@spontifixus
+// @name           IITC plugin: Remove Portal Resizing
+// @category       Highlighter
+// @version        0.1.0.@@DATETIMEVERSION@@
+// @namespace      https://github.com/jonatkins/ingress-intel-total-conversion
+// @updateURL      @@UPDATEURL@@
+// @downloadURL    @@DOWNLOADURL@@
+// @description    [@@BUILDNAME@@-@@BUILDDATE@@] Shows all portals using the same size. Combine with the portal-level-numbers plugin to denote the portal level.
+// @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
+// @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
+// @grant          none
+// ==/UserScript==
+
+@@PLUGINSTART@@
+
+// PLUGIN START ////////////////////////////////////////////////////////
+
+// use own namespace for plugin
+window.plugin.portalHighlighterNoResize = function() {};
+
+window.plugin.portalHighlighterNoResize.highlight = function(data) {
+  var scale = window.portalMarkerScale();
+  var params = {
+	radius: 7 * scale + (L.Browser.mobile ? PORTAL_RADIUS_ENLARGE_MOBILE * scale : 0),
+	weight: 2
+  };
+  data.portal.setStyle(params);
+}
+
+var setup =  function() {
+  window.addPortalHighlighter('Remove Portal Resizing', window.plugin.portalHighlighterNoResize.highlight);
+}
+
+// PLUGIN END //////////////////////////////////////////////////////////
+
+@@PLUGINEND@@


### PR DESCRIPTION
I have added a plugin that removes the different sizes of the portals as rendered by the default iitc map. Would be great if that plugin could be added to the list of plugins!

Greetings,
Markus