### PR TITLE
Support cell text in Safari mobile browser

### DIFF
--- a/style.css
+++ b/style.css
@@ -631,7 +631,7 @@ h3 {
   vertical-align: top;
   white-space: nowrap;
   width: 50%;
-  width: calc(50% - 62px);
+  width: calc(50%);
 }
 
 #randdetails th, #resodetails th {


### PR DESCRIPTION
Remove subtraction of 62px from #randdetails, #resodetails to render detailed portal view portion on mobile Safari properly.

More context: https://plus.google.com/100967940662391986171/posts/CP61LP2qyBL