### PR TITLE
Make cross-links easier to identify

### DIFF
--- a/plugins/cross_link.user.js
+++ b/plugins/cross_link.user.js
@@ -220,7 +220,18 @@ window.plugin.crossLinks.showLink = function(link) {
        guid: link.options.guid
     });
 
+    var poly2 = L.geodesicPolyline(link.getLatLngs(), {
+      color: COLORS[link.options.team],
+      opacity: 0.3,
+      weight: 50,
+      clickable: false,
+      dashArray: [8,8],
+
+      guid: link.options.guid
+    });
+
     poly.addTo(plugin.crossLinks.linkLayer);
+    poly2.addTo(plugin.crossLinks.linkLayer);
     plugin.crossLinks.linkLayerGuids[link.options.guid]=poly;
 }
 


### PR DESCRIPTION
Draw a easier to see halo around cross links to make them much easier to identify.