### PR TITLE
New plugin that allows the user to pick portals to be used as input for the maxfield script

### DIFF
--- a/plugins/pick-maxfield-portals.css
+++ b/plugins/pick-maxfield-portals.css
@@ -1,0 +1,5 @@
+.ui-dialog-pickmaxfieldportals-copy textarea{
+	width:96%;
+	height:120px;
+	resize:vertical;
+}

--- a/plugins/pick-maxfield-portals.user.js
+++ b/plugins/pick-maxfield-portals.user.js
@@ -1,0 +1,150 @@
+// ==UserScript==
+// @id             iitc-plugin-pick-maxfield-portals
+// @name           IITC plugin: pick portals for the maxfield script
+// @category       Info
+// @version        0.1.0.@@DATETIMEVERSION@@
+// @namespace      https://github.com/jonatkins/ingress-intel-total-conversion
+// @updateURL      @@UPDATEURL@@
+// @downloadURL    @@DOWNLOADURL@@
+// @description    [@@BUILDNAME@@-@@BUILDDATE@@] Pick portals for the maxfield script.
+// @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
+// @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
+// @grant          none
+// ==/UserScript==
+
+@@PLUGINSTART@@
+
+// PLUGIN START ////////////////////////////////////////////////////////
+
+// use own namespace for plugin
+plugin.pickmaxfieldportals = function() {};
+
+plugin.pickmaxfieldportals.resetSelectedPortals = function() {
+  plugin.pickmaxfieldportals.selectedPortals = {};
+}
+
+plugin.pickmaxfieldportals.getMaxfieldInputLine = function() {
+  var portal = window.portals[window.selectedPortal];
+  var info = portal.options.data.title + ";" + $('.linkdetails aside a')[0].href + ";";
+  return info;
+}
+
+plugin.pickmaxfieldportals.onAddClick = function() {
+
+  if(!window.selectedPortal) {
+    alert("No portal selected!");
+    return false;
+  }
+
+  var portalId = window.portals[window.selectedPortal].options.ent[0];
+  var info = plugin.pickmaxfieldportals.getMaxfieldInputLine();
+
+  // avoid duplicates
+  if(!plugin.pickmaxfieldportals.selectedPortals[portalId]) {
+    plugin.pickmaxfieldportals.selectedPortals[portalId] = info;
+  }
+
+  window.runHooks('pluginPickmaxfieldportalsChange');
+};
+
+plugin.pickmaxfieldportals.onDelClick = function() {
+
+  if(!window.selectedPortal) {
+    alert("No portal selected!");
+    return false;
+  }
+
+  var portalId = window.portals[window.selectedPortal].options.ent[0];
+  if(plugin.pickmaxfieldportals.selectedPortals[portalId]) {
+    delete plugin.pickmaxfieldportals.selectedPortals[portalId];
+  }
+
+  window.runHooks('pluginPickmaxfieldportalsChange');
+};
+
+plugin.pickmaxfieldportals.onShowClick = function() {
+
+  if($.isEmptyObject(plugin.pickmaxfieldportals.selectedPortals)) {
+    alert("You haven't added any portals!");
+  } else {
+    var maxfieldInput = $.map(plugin.pickmaxfieldportals.selectedPortals, function(inputLine, portalId) {
+      return inputLine;
+    }).join('\n');
+
+    dialog({
+      html: '<p><a onclick="$(\'.ui-dialog-pickmaxfieldportals-copy textarea\').select();">Select all</a> and copy contents.</p><textarea readonly>' + maxfieldInput + '</textarea>',
+      dialogClass: 'ui-dialog-pickmaxfieldportals-copy',
+      title: 'Maxfield Input Export'
+    });
+  }
+};
+
+plugin.pickmaxfieldportals.onResetClick = function() {
+
+  plugin.pickmaxfieldportals.resetSelectedPortals();
+  window.runHooks('pluginPickmaxfieldportalsChange');
+
+  alert("Portal selection has been reset.");
+};
+
+plugin.pickmaxfieldportals.createButton = function(title, tooltip, handler) {
+
+	var button = document.createElement("a");
+	button.className = "leaflet-bar-part";
+	button.title = title;
+
+	var tt = document.createElement("div");
+  tt.innerHTML = tooltip;
+	button.appendChild(tt);
+
+  button.addEventListener("click", handler, false);
+
+  return button;
+}
+
+window.plugin.pickmaxfieldportals.highlight = function(data) {
+  var portalId = data.portal.options.ent[0];
+  if(plugin.pickmaxfieldportals.selectedPortals[portalId]) {
+    data.portal.setStyle({fillColor: 'black', fillOpacity: 100});
+  }
+}
+
+window.plugin.pickmaxfieldportals.highlightRefresh = function() {
+
+  window.resetHighlightedPortals();
+}
+
+var setup =  function() {
+
+  // initialize selected portals
+  plugin.pickmaxfieldportals.resetSelectedPortals();
+
+  // define hook for highlight refresh
+  if($.inArray('pluginPickmaxfieldportalsChange', window.VALID_HOOKS) < 0) { window.VALID_HOOKS.push('pluginPickmaxfieldportalsChange'); }
+  window.addHook('pluginPickmaxfieldportalsChange', plugin.pickmaxfieldportals.highlightRefresh);
+
+  // create toolbar buttons
+  var parent = $(".leaflet-top.leaflet-left", window.map.getContainer());
+
+  var container = document.createElement("div");
+	container.className = "leaflet-bar leaflet-control";
+
+	container.appendChild(plugin.pickmaxfieldportals.createButton("Add Portal", "A", plugin.pickmaxfieldportals.onAddClick));
+  container.appendChild(plugin.pickmaxfieldportals.createButton("Delete Portal", "D", plugin.pickmaxfieldportals.onDelClick));
+  container.appendChild(plugin.pickmaxfieldportals.createButton("Show Script Input", "S", plugin.pickmaxfieldportals.onShowClick));
+  container.appendChild(plugin.pickmaxfieldportals.createButton("Reset", "R", plugin.pickmaxfieldportals.onResetClick));
+
+  parent.append(container);
+
+  // inject css
+  $('<style>').prop('type', 'text/css').html('@@INCLUDESTRING:plugins/pick-maxfield-portals.css@@').appendTo('head');
+
+  // add highlighter
+  window.addPortalHighlighter('Maxfield Portals', plugin.pickmaxfieldportals.highlight);
+};
+
+// PLUGIN END //////////////////////////////////////////////////////////
+
+@@PLUGINEND@@


### PR DESCRIPTION
I've used the maxfield script by Baker and Wenger a couple of times. I always found it tedious to pick out all the portal details manually. I've now created an IITC plugin that allows the user to add portals to a list that can then be exported to be used as direct input to the maxfield script. It's a basic implementation with a simple sidebar button GUI and I would love to see some people testing it and providing comments on this.