### PR TITLE
Variation of reso energy % for days remaining

### DIFF
--- a/plugins/reso-energy-days-in-portal-detail.user.js
+++ b/plugins/reso-energy-days-in-portal-detail.user.js
@@ -1,0 +1,70 @@
+// ==UserScript==
+// @id             iitc-plugin-reso-energy-days-in-portal-detail@xelio
+// @name           IITC plugin: reso energy days in portal detail
+// @category       Portal Info
+// @version        0.1.2.@@DATETIMEVERSION@@
+// @namespace      https://github.com/jonatkins/ingress-intel-total-conversion
+// @updateURL      @@UPDATEURL@@
+// @downloadURL    @@DOWNLOADURL@@
+// @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show resonator energy days remaining on resonator energy bar in portal detail panel.
+// @include        https://www.ingress.com/intel*
+// @include        http://www.ingress.com/intel*
+// @match          https://www.ingress.com/intel*
+// @match          http://www.ingress.com/intel*
+// @include        https://www.ingress.com/mission/*
+// @include        http://www.ingress.com/mission/*
+// @match          https://www.ingress.com/mission/*
+// @match          http://www.ingress.com/mission/*
+// @grant          none
+// ==/UserScript==
+
+@@PLUGINSTART@@
+
+function wrapper(plugin_info) {
+    // ensure plugin framework is there, even if iitc is not yet loaded
+    if (typeof window.plugin !== 'function') window.plugin = function () { };
+
+    // PLUGIN START ////////////////////////////////////////////////////////
+
+    // use own namespace for plugin
+    window.plugin.resoEnergyDaysInPortalDetail = function () { };
+
+    window.plugin.resoEnergyDaysInPortalDetail.updateMeter = function (data) {
+        $("span.meter-level")
+          .css({
+              "word-spacing": "-1px",
+              "text-align": "left",
+              "font-size": "90%",
+              "padding-left": "2px",
+          })
+          .each(function () {
+              var matchResult = $(this).parent().attr('title').match(/energy:\s+(\d+)\s+\/\s+(\d+)\s+/);
+
+              if (matchResult) {
+                  var decayRate = matchResult[2] * 0.15;
+                  var daysRemaining = Math.floor(matchResult[1] / decayRate);
+                  var html = $(this).html() + '<div style="position:absolute;right:0;top:0">' + daysRemaining + 'd</div>';
+                  $(this).html(html);
+              }
+          });
+    }
+
+    var setup = function () {
+        window.addHook('portalDetailsUpdated', window.plugin.resoEnergyDaysInPortalDetail.updateMeter);
+    }
+
+    // PLUGIN END //////////////////////////////////////////////////////////
+
+
+    setup.info = plugin_info; //add the script info data to the function as a property
+    if (!window.bootPlugins) window.bootPlugins = [];
+    window.bootPlugins.push(setup);
+    // if IITC has already booted, immediately run the 'setup' function
+    if (window.iitcLoaded && typeof setup === 'function') setup();
+} // wrapper end
+// inject code into site context
+var script = document.createElement('script');
+var info = {};
+if (typeof GM_info !== 'undefined' && GM_info && GM_info.script) info.script = { version: GM_info.script.version, name: GM_info.script.name, description: GM_info.script.description };
+script.appendChild(document.createTextNode('(' + wrapper + ')(' + JSON.stringify(info) + ');'));
+(document.body || document.head || document.documentElement).appendChild(script);


### PR DESCRIPTION
A simple adaption of reso-energy-pct-in-portal-details.user.js where instead of displaying the remaining percentage, it calculates the decay rate (15% of max per day) and displays the (pessimistic) number of days remaining based on the remaining energy. Screenshot:

![reso-energy-days-in-portal-detail](https://cloud.githubusercontent.com/assets/13812344/9292935/a49983f8-440b-11e5-9cf1-a236095ab32f.jpg)

Issues: If both days and % scripts are enabled, they will both display and look garbled. There are plenty of ways to work around this but as this is my first contribution to IITC and UI dev is not generally my area of expertise, I'm happy to take suggestions, or for someone else to roll it in to the pct script. Screenshot:

![reso-energy-days-in-portal-detail-issue](https://cloud.githubusercontent.com/assets/13812344/9292943/19ecd2ae-440c-11e5-9b48-37d7146fa646.jpg)
