### PR TITLE
Add removeLayerGroup

### DIFF
--- a/code/utils_misc.js
+++ b/code/utils_misc.js
@@ -414,6 +414,15 @@ window.addLayerGroup = function(name, layerGroup, defaultDisplay) {
   layerChooser.addOverlay(layerGroup, name);
 }
 
+window.removeLayerGroup = function(layerGroup) {
+  // removing the layer will set it's default visibility to false (store if layer gets added again)
+  var name = layerChooser._layers[layerGroup._leaflet_id].name;
+  var enabled = isLayerGroupDisplayed(name);
+  map.removeLayer(layerGroup);
+  layerChooser.removeLayer(layerGroup);
+  updateDisplayedLayerGroup(name, enabled);
+};
+
 window.clampLat = function(lat) {
   // the map projection used does not handle above approx +- 85 degrees north/south of the equator
   if (lat > 85.051128)
@@ -476,4 +485,3 @@ L.Draggable.prototype._onDown = function(e) {
     L.DomEvent.on(document, "touchcancel", this._onUp, this);
   }
 }
-


### PR DESCRIPTION
- removes a layer from the layerChooser
- store the currently selection state if added later.

Refers issues #1054. On @fkloft recommendation I close the issue as a duplicate to the PR.