### PR TITLE
Add tooltip to player name in portal detail view, Closes #1078

### DIFF
--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -146,7 +146,7 @@ window.getPortalMiscDetails = function(guid,d) {
     var linksText = ['links', links.outgoing+' out / '+links.incoming+' in', title];
 
     var player = d.owner
-      ? '<span class="nickname">' + d.owner + '</span>'
+      ? '<a href="#" class="nickname" title="'+ d.owner +'">' + d.owner + '</a>'
       : '-';
     var playerText = ['owner', player];
 


### PR DESCRIPTION
Update html code for portal details view to show a
tooltip for the player-name on mouse-over.

regards
~david

_Note:_ I could only test it in the desktop version so far.

Closes #1078