### PR TITLE
Move and zoom to portal double clicking its title.

### DIFF
--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -90,12 +90,18 @@ window.renderPortalDetails = function(guid) {
 
   }
 
+  var zoomOnClick = 'zoomToAndShowPortal(\''+guid+'\',['+data.latE6/1E6+','+data.lngE6/1E6+']);';
+    
   $('#portaldetails')
     .html('') //to ensure it's clear
     .attr('class', TEAM_TO_CSS[teamStringToId(data.team)])
     .append(
-      $('<h3>').attr({class:'title'}).text(title),
-
+      $('<h3>').attr({
+        class:'title',
+        title: title + '\n\nDouble click to move to portal.',
+        ondblclick: zoomOnClick,
+      }).text(title),
+      
       $('<span>').attr({
         class: 'close',
         title: 'Close [w]',


### PR DESCRIPTION
Move and zoom to portal double clicking its title in portal detail view. 
Portal click in chat doesn't center a portal and sometimes it appears under the chat (sometimes portal selection doesn't work at all for me). Another situation is when you moved the map away from the selected portal and want to see it again. Anyway if you see portal info you should have the ability to move to it simply.

Also full name of a portal is in hint now. It is useful in case it is too long and was truncated.