### PR TITLE
Bookmarks: update location of highlighter dropdown

### DIFF
--- a/plugins/bookmarks-by-zaso.css
+++ b/plugins/bookmarks-by-zaso.css
@@ -733,3 +733,7 @@
 #bkmrksSetbox{
 	text-align:center;
 }
+#portal_highlight_select{
+	top:35px;
+	left:45px;
+}


### PR DESCRIPTION
This will re-position the drop down box of the bookmarks plugin further down right so it does not interfere with the location of the scale plugin.