### PR TITLE
Add drawtools support and improve portal list display.

### DIFF
--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -32,6 +32,10 @@
   text-align: right;
 }
 
+#portalslist table .hiddenColumn {
+  display: none;
+}
+
 #portalslist table.portals td {
   white-space: nowrap;
 }

--- a/plugins/portals-list.user.js
+++ b/plugins/portals-list.user.js
@@ -25,14 +25,6 @@
 // use own namespace for plugin
 window.plugin.portalslist = function() {};
 
-window.plugin.portalslist.listPortals = [];
-window.plugin.portalslist.sortBy = 1; // second column: level
-window.plugin.portalslist.sortOrder = -1;
-window.plugin.portalslist.enlP = 0;
-window.plugin.portalslist.resP = 0;
-window.plugin.portalslist.neuP = 0;
-window.plugin.portalslist.filter = 0;
-
 /*
  * plugins may add fields by appending their specifiation to the following list. The following members are supported:
  * title: String
@@ -53,6 +45,30 @@ window.plugin.portalslist.filter = 0;
 
 
 window.plugin.portalslist.fields = [
+  {
+    title: "Lat",
+    titleClass: "hiddenColumn",
+    value: function(portal) { return portal.getLatLng().lat; },
+    format: function(cell, portal, value) {
+      $(cell)
+        .addClass("alignR")
+        .addClass("hiddenColumn")
+        .text(value);
+    },
+    defaultOrder: -1,
+  },
+  {
+    title: "Lng",
+    titleClass: "hiddenColumn",
+    value: function(portal) { return portal.getLatLng().lng; },
+    format: function(cell, portal, value) {
+      $(cell)
+        .addClass("alignR")
+        .addClass("hiddenColumn")
+        .text(value);
+    },
+    defaultOrder: -1,
+  },
   {
     title: "Portal Name",
     value: function(portal) { return portal.options.data.title; },
@@ -116,7 +132,7 @@ window.plugin.portalslist.fields = [
   },
   {
     title: "Fields",
-    value: function(portal) { return getPortalFieldsCount(portal.options.guid) },
+    value: function(portal) { return getPortalFieldsCount(portal.options.guid); },
     format: function(cell, portal, value) {
       $(cell)
         .addClass("alignR")
@@ -147,35 +163,122 @@ window.plugin.portalslist.fields = [
         .addClass("alignR")
         .addClass('help')
         .prop('title', title)
-        .html(digits(value.enemyAp));
+        .html(/* digits */ (value.enemyAp)); // XXX removed thinspace for export
     },
     defaultOrder: -1,
   },
 ];
 
-//fill the listPortals array with portals avaliable on the map (level filtered portals will not appear in the table)
-window.plugin.portalslist.getPortals = function() {
-  //filter : 0 = All, 1 = Neutral, 2 = Res, 3 = Enl, -x = all but x
-  var retval=false;
+/*
+pnpoly Copyright (c) 1970-2003, Wm. Randolph Franklin
 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+     disclaimers.
+  2. Redistributions in binary form must reproduce the above copyright notice in the documentation and/or other
+     materials provided with the distribution.
+  3. The name of W. Randolph Franklin may not be used to endorse or promote products derived from this Software without
+     specific prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+window.plugin.portalslist.pnpoly = function(latlngs, point) {
+	var length = latlngs.length, c = false;
+
+	for(var i = 0, j = length - 1; i < length; j = i++) {
+		if(((latlngs[i].lat > point.lat) != (latlngs[j].lat > point.lat)) &&
+		  (point.lng < latlngs[i].lng
+		  + (latlngs[j].lng - latlngs[i].lng) * (point.lat - latlngs[i].lat)
+		  / (latlngs[j].lat - latlngs[i].lat))) {
+			c = !c;
+		}
+	}
+
+	return c;
+};
+
+// interesting layer to us?
+window.plugin.portalslist.closedLayer = function (layer) {
+  return layer instanceof L.GeodesicPolygon ||
+         layer instanceof L.Polygon ||
+         layer instanceof L.GeodesicCircle ||
+         layer instanceof L.Circle;
+};
+
+// is the portal inside any polygon
+window.plugin.portalslist.portalInDrawnItems = function (portal) {
+  var InDrawnItem = false;
+  var point = portal.getLatLng();
+
+  window.plugin.drawTools.drawnItems.eachLayer(function(layer) {
+    if (window.plugin.portalslist.closedLayer(layer) &&
+        window.plugin.portalslist.pnpoly(layer.getLatLngs(), point)) {
+      InDrawnItem = true;
+    }
+  });
+  return InDrawnItem;
+};
+
+// turn on polygon filtering if
+// we have draw tools, that layer group is visible, there are layers,
+// and at least one layer has some sort of a closed polygon
+window.plugin.portalslist.checkPolygons = function() {
+  filter_by_polygon = false;
+
+  if (window.plugin.drawTools &&
+      window.isLayerGroupDisplayed('Drawn Items', true) &&
+      window.plugin.drawTools.drawnItems.getLayers().length > 0) {
+    window.plugin.drawTools.drawnItems.eachLayer(function(layer) {
+      if (window.plugin.portalslist.closedLayer(layer)) {
+        filter_by_polygon = true;
+      }
+    });
+  }
+
+  return filter_by_polygon;
+};
+
+//fill the listPortals array with portals avaliable on the map (level filtered portals will not appear in the table)
+window.plugin.portalslist.getPortals = function(mode) {
+  //filter : 0 = All, 1 = Neutral, 2 = Res, 3 = Enl, -x = all but x
   var displayBounds = map.getBounds();
+  var checkPoly = window.plugin.portalslist.checkPolygons();
 
   window.plugin.portalslist.listPortals = [];
+  window.plugin.portalslist.filter = 0;
+  window.plugin.portalslist.portalcount = [ 0, 0, 0 ];
+  window.plugin.portalslist.levelcount = [
+    [ 0 ],
+    [ 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+    [ 0, 0, 0, 0, 0, 0, 0, 0, 0 ] ];
+
+  var storage = {};
+
   $.each(window.portals, function(i, portal) {
     // eliminate offscreen portals (selected, and in padding)
-    if(!displayBounds.contains(portal.getLatLng())) return true;
+    if(!displayBounds.contains(portal.getLatLng()))
+      return;
 
-    retval=true;
+    // eliminate portals outside of polygons if drawn items are present
+    if(checkPoly && !window.plugin.portalslist.portalInDrawnItems(portal))
+      return;
 
-    switch (portal.options.team) {
-      case TEAM_RES:
-        window.plugin.portalslist.resP++;
-        break;
-      case TEAM_ENL:
-        window.plugin.portalslist.enlP++;
-        break;
-      default:
-        window.plugin.portalslist.neuP++;
+    window.plugin.portalslist.portalcount[portal.options.team]++;
+
+    // count the number of portals at a particular level for a summary
+    window.plugin.portalslist.levelcount[portal.options.team][portal.options.level]++;
+
+    if (mode) {
+      if (mode == "full")
+	  storage[portal.options.guid] = portal.options.data;
+      return;
     }
 
     // cache values and DOM nodes
@@ -185,7 +288,13 @@ window.plugin.portalslist.getPortals = function() {
     row.className = TEAM_TO_CSS[portal.options.team];
     obj.row = row;
 
+    // first column is always GUID (hidden, but exported)
     var cell = row.insertCell(-1);
+    cell.textContent = portal.options.guid;
+    cell.classList.add("hiddenColumn");
+
+    // empty number column (to be filled in later)
+    cell = row.insertCell(-1);
     cell.className = 'alignR';
 
     window.plugin.portalslist.fields.forEach(function(field, i) {
@@ -206,20 +315,95 @@ window.plugin.portalslist.getPortals = function() {
     window.plugin.portalslist.listPortals.push(obj);
   });
 
-  return retval;
-}
+  if (mode) {
+    var flattened = window.plugin.portalslist.levelcount.reduce(function (a, b) {
+	return a.concat(b);
+    });
+    var total = flattened.reduce(function(a, b) {
+	return a + b;
+    });
+
+    var data = {
+      'type': 'portal-census',
+      'timestamp': Date.now(),
+      'total-count': total,
+      'level-summary': window.plugin.portalslist.levelcount,
+    }
+    if (mode == 'full')
+      data.portals = storage
+
+    return data;
+  }
+};
+
+// Export the portal list in a CSV format file.
+// First line is current date presented three ways (unixtime, ISO8601, and DOW, Human Readable)
+// Second line is headers
+// Rest is table data
+window.plugin.portalslist.exportCSV = function() {
+  // Temporary delimiter characters unlikely to be typed by keyboard
+  // This is to avoid accidentally splitting the actual contents
+  var tmpColDelim = String.fromCharCode(11), // vertical tab character
+      tmpRowDelim = String.fromCharCode(0),  // null character
+      colDelim = ',',		// actual delimiters
+      rowDelim = '\n';
+
+  var date = new Date();
+  var csv = date.getTime() + colDelim + date.toISOString() + colDelim + date + rowDelim;
+
+  ["th", "td"].forEach(function(label, i) {
+    var $rows = $('table.portals').find('tr:has(' + label + ')');
+
+    // Grab text from table into CSV formatted string
+    csv += $rows.map(function (i, row) {
+      var $row = $(row),
+	  $cols = $row.find(label);
+
+      return $cols.map(function (j, col) {
+	var $col = $(col),
+	    text = $col.text();
+	    text = text.replace(/,/g, '');
+	    text = text.replace(/ +$/, ''); // remove trailing whitespace
+//          text = text.replace(/(\d) (?=(\d\d\d)+(?!\d))/g,"$1"); // remove digit spaces
+	    text = text.replace(/\+\-$/,''); // remove key +/- if present
+
+	return text.replace(/"/g, '""'); // escape double quotes
+       }).get().join(tmpColDelim);
+     }).get().join(tmpRowDelim)
+	     .split(tmpRowDelim).join(rowDelim)
+	     .split(tmpColDelim).join(colDelim) + rowDelim;
+   });
+
+   // Data URI
+   var csvData = 'data:application/csv;charset=utf-8,' + encodeURIComponent(csv);
+
+   // If we're running a sane browser, we can specify a nice filename
+   // If there's no support for the html a download tag, fall back to window.open
+   try {
+     var a = document.createElement('a');
+     if (!('download' in a)) throw 'a does not support download';
+     a.href = csvData;
+     a.target = '_self';
+     a.class = 'dataURLdownloader';
+     a.download = 'export-' + date.toISOString() + '.csv';
+     document.body.appendChild(a);
+     a.click();
+   } catch(e) {
+     errormsg = 'error on CSV export: ' + e;
+     console.log(errormsg);
+     if (strict) throw errormsg;
+     window.open(csvData, '_self');
+   }
+};
 
 window.plugin.portalslist.displayPL = function() {
   var list;
   // plugins (e.g. bookmarks) can insert fields before the standard ones - so we need to search for the 'level' column
   window.plugin.portalslist.sortBy = window.plugin.portalslist.fields.map(function(f){return f.title;}).indexOf('Level');
   window.plugin.portalslist.sortOrder = -1;
-  window.plugin.portalslist.enlP = 0;
-  window.plugin.portalslist.resP = 0;
-  window.plugin.portalslist.neuP = 0;
-  window.plugin.portalslist.filter = 0;
 
-  if (window.plugin.portalslist.getPortals()) {
+  window.plugin.portalslist.getPortals(false);
+  if (window.plugin.portalslist.listPortals.length > 0) {
     list = window.plugin.portalslist.portalTable(window.plugin.portalslist.sortBy, window.plugin.portalslist.sortOrder,window.plugin.portalslist.filter);
   } else {
     list = $('<table class="noPortals"><tr><td>Nothing to show!</td></tr></table>');
@@ -231,12 +415,15 @@ window.plugin.portalslist.displayPL = function() {
     dialog({
       html: $('<div id="portalslist">').append(list),
       dialogClass: 'ui-dialog-portalslist',
-      title: 'Portal list: ' + window.plugin.portalslist.listPortals.length + ' ' + (window.plugin.portalslist.listPortals.length == 1 ? 'portal' : 'portals'),
+      title: 'Portal list: ' + window.plugin.portalslist.listPortals.length + ' ' + (window.plugin.portalslist.listPortals.length == 1 ? 'portal' : 'portals') + (window.plugin.portalslist.checkPolygons() ? " (inside visible polygons)" : ""),
       id: 'portal-list',
       width: 700
+    }).dialog('option', 'buttons', {
+      'Export': function() { window.plugin.portalslist.exportCSV(); },
+      'OK': function() { $(this).dialog('close'); },
     });
   }
-}
+};
 
 window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
   // save the sortBy/sortOrder/filter
@@ -300,18 +487,43 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
       $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, -i));
     });
 
-    switch(i-1) {
-      case -1:
-        cell.textContent = length;
-        break;
-      case 0:
-        cell.textContent = window.plugin.portalslist.neuP + ' (' + Math.round(window.plugin.portalslist.neuP/length*100) + '%)';
-        break;
-      case 1:
-        cell.textContent = window.plugin.portalslist.resP + ' (' + Math.round(window.plugin.portalslist.resP/length*100) + '%)';
-        break;
-      case 2:
-        cell.textContent = window.plugin.portalslist.enlP + ' (' + Math.round(window.plugin.portalslist.enlP/length*100) + '%)';
+    if (i == 0) {
+	cell.textContent = length; // all portals
+    } else {
+        cell.textContent = window.plugin.portalslist.portalcount[i-1] + ' (' + Math.round(window.plugin.portalslist.portalcount[i-1]/length*100) + '%)';
+    }
+  });
+
+  table = document.createElement('table');
+  table.className = 'levelcount';
+  container.append(table);
+
+  row = table.insertRow(-1);
+
+  cell = row.appendChild(document.createElement('th'));
+  cell.textContent = 'Team Count';
+  for (var level = 1; level <= MAX_PORTAL_LEVEL; level++) {
+    cell = row.appendChild(document.createElement('th'));
+    $(cell)
+      .text('L' + level)
+      .css('background-color', COLORS_LVL[level])
+      .addClass('alignR');
+  }
+
+  ["Neutral", "Resistance", "Enlightened"].forEach(function(label, team) {
+    if (team > 0) { // Neutral is redundant
+      row = table.insertRow(-1);
+	  row.className = TEAM_TO_CSS[team];
+	  cell = row.appendChild(document.createElement('td'));
+	  $(cell)
+	    .addClass('filter' + label.substr(0, 3))
+		.text(label);
+	  for (var level = 1; level <= MAX_PORTAL_LEVEL; level++) {
+		cell = row.appendChild(document.createElement('td'));
+		$(cell)
+		  .addClass('alignR')
+		  .text(window.plugin.portalslist.levelcount[team][level]);
+	  }
     }
   });
 
@@ -323,11 +535,18 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
   row = thead.insertRow(-1);
 
   cell = row.appendChild(document.createElement('th'));
+  cell.textContent = 'GUID';
+  cell.classList.add("hiddenColumn");
+
+  cell = row.appendChild(document.createElement('th'));
   cell.textContent = '#';
 
   window.plugin.portalslist.fields.forEach(function(field, i) {
     cell = row.appendChild(document.createElement('th'));
     cell.textContent = field.title;
+    if(field.titleClass) {
+      cell.classList.add(field.titleClass);
+    }
     if(field.sort !== null) {
       cell.classList.add("sortable");
       if(i == window.plugin.portalslist.sortBy) {
@@ -351,7 +570,8 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
     var row = obj.row
     if(row.parentNode) row.parentNode.removeChild(row);
 
-    row.cells[0].textContent = i+1;
+    // second column in table, but first visible column is the # field
+    row.cells[1].textContent = i+1;
 
     table.appendChild(row);
   });
@@ -360,7 +580,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
     + 'Click on <b>All, Neutral, Resistance, Enlightened</b> to only show portals owner by that faction or on the number behind the factions to show all but those portals.</div>');
 
   return container;
-}
+};
 
 // portal link - single click: select portal
 //               double click: zoom to and select portal
@@ -384,7 +604,7 @@ window.plugin.portalslist.getPortalLink = function(portal) {
     return false;
   });
   return link;
-}
+};
 
 window.plugin.portalslist.onPaneChanged = function(pane) {
   if(pane == "plugin-portalslist")
@@ -406,7 +626,7 @@ var setup =  function() {
     .html("@@INCLUDESTRING:plugins/portals-list.css@@")
     .appendTo("head");
 
-}
+};
 
 // PLUGIN END //////////////////////////////////////////////////////////
 


### PR DESCRIPTION
I rewrote this code a long time ago but Jon had stopped maintaining IITC by then, so I closed out the pull requests.

If a polygon is in the display window, this code will limit the code under the portals list to just the portals in the polygon.  It also makes several improvements, including a .CSV export, of the data in question.  Originally I had submitted this as two pull requests in case the export thing was an issue, but honestly, it adds no additional load to the servers and at this point, it beats the alternative grey stuff that is floating around.  There are completely legitimate reasons for it.

If you have a major issue with it, you can just eliminate the exportCSV function and the call to it, it's obvious.