### PR TITLE
Add a wider color band around cross-links

### DIFF
--- a/plugins/cross_link.user.js
+++ b/plugins/cross_link.user.js
@@ -220,7 +220,18 @@ window.plugin.crossLinks.showLink = function(link) {
        guid: link.options.guid
     });
 
+    var poly2 = L.geodesicPolyline(link.getLatLngs(), {
+      color: COLORS[link.options.team],
+      opacity: 0.3,
+      weight: 50,
+      clickable: false,
+      dashArray: [8,8],
+
+      guid: link.options.guid
+    });
+
     poly.addTo(plugin.crossLinks.linkLayer);
+    poly2.addTo(plugin.crossLinks.linkLayer);
     plugin.crossLinks.linkLayerGuids[link.options.guid]=poly;
 }
 


### PR DESCRIPTION
Add a "team colored" wider band to make it easier to distinguish cross links.