### PR TITLE
Allow offical plugins to be searched on mobile app

### DIFF
--- a/mobile/AndroidManifest.xml
+++ b/mobile/AndroidManifest.xml
@@ -146,6 +146,14 @@
                     android:pathPattern=".*\\.user.js"
                     android:scheme="https"/>
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEARCH"/>
+            </intent-filter>
+
+            <meta-data
+                android:name="android.app.searchable"
+                android:resource="@xml/pluginsearchable" />
         </activity>
 
         <activity
@@ -209,6 +217,12 @@
         <meta-data
             android:name="android.app.default_searchable"
             android:value="com.cradle.iitc_mobile.IITC_Mobile"/>
+
+        <provider
+            android:authorities="com.cradle.iitc_mobile.PluginProvider"
+            android:name="com.cradle.iitc_mobile.prefs.PluginProvider"
+            android:exported="false"
+            android:syncable="false" />
     </application>
 
 </manifest>

--- a/mobile/res/menu/plugins.xml
+++ b/mobile/res/menu/plugins.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <item
+        android:id="@+id/action_search"
+        android:icon="@android:drawable/ic_menu_search"
+        android:showAsAction="ifRoom"
+        android:actionViewClass="android.widget.SearchView"
+        android:title="@string/menu_search" />
     <item
         android:id="@+id/menu_plugins_add"
         android:icon="@drawable/ic_action_new"

--- a/mobile/res/values/strings.xml
+++ b/mobile/res/values/strings.xml
@@ -218,6 +218,7 @@
     <string name="choose_account_to_login">Choose account to login</string>
     <string name="login_failed">Login failed.</string>
     <string name="search_hint">Search Locations</string>
+    <string name="search_hint_plugin">Search Plugins</string>
     <string name="intent_error">Address could not be opened</string>
     <string name="msg_copied">Copied to clipboard…</string>
     <string name="notice_do_not_show_again">Do not show again</string>

--- a/mobile/res/xml/pluginsearchable.xml
+++ b/mobile/res/xml/pluginsearchable.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<searchable xmlns:android="http://schemas.android.com/apk/res/android"
+    android:label="@string/app_name"
+    android:hint="@string/search_hint_plugin"
+    android:searchSuggestAuthority="com.cradle.iitc_mobile.PluginProvider"
+    android:searchSuggestIntentAction="iitc.search.plugin"
+    android:searchSuggestIntentData="content://com.cradle.iitc_mobile.PluginProvider/plugin"
+    android:searchSuggestSelection=" ?"
+    android:searchSuggestThreshold="1">
+</searchable>

--- a/mobile/src/com/cradle/iitc_mobile/prefs/PluginDatabase.java
+++ b/mobile/src/com/cradle/iitc_mobile/prefs/PluginDatabase.java
@@ -1,0 +1,75 @@
+package com.cradle.iitc_mobile.prefs;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.DatabaseUtils;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import android.database.sqlite.SQLiteStatement;
+
+import java.util.Hashtable;
+
+import static android.app.SearchManager.SUGGEST_COLUMN_INTENT_EXTRA_DATA;
+import static android.app.SearchManager.SUGGEST_COLUMN_QUERY;
+import static android.app.SearchManager.SUGGEST_COLUMN_TEXT_1;
+
+/**
+ * SQLite database to store mappings of plugin names and their categories.
+ * When search text is entered, it is matched to any plugin name that starts with the text.
+ */
+public class PluginDatabase extends SQLiteOpenHelper {
+    private static final String DB_NAME = "plugins.sqlite", COL_ID = "_id", TABLE_SEARCH = "search";
+
+    private static final int VERSION = 1;
+
+    PluginDatabase(Context context) {
+        super(context, DB_NAME, null, VERSION);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        // Create the "search" table, which is a mapping of plugin titles and their category
+        db.execSQL(String.format("create table %s ( _id integer primary key autoincrement, %s text, %s text, %s text)", TABLE_SEARCH, SUGGEST_COLUMN_TEXT_1, SUGGEST_COLUMN_QUERY, SUGGEST_COLUMN_INTENT_EXTRA_DATA));
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        // implement schema changes and data massage here when upgrading
+    }
+
+    void addPlugins(Hashtable<String, String> pluginData) {
+        SQLiteDatabase DB = getWritableDatabase();
+        DB.beginTransaction();
+
+        // Iterate through all keys from hash table to populate database table
+        SQLiteStatement search = DB.compileStatement(String.format("insert into %s (%s, %s, %s) values (?, ?, ?);", TABLE_SEARCH, SUGGEST_COLUMN_TEXT_1, SUGGEST_COLUMN_QUERY, SUGGEST_COLUMN_INTENT_EXTRA_DATA));
+        for(String title : pluginData.keySet()) {
+            search.bindString(1, title);
+            search.bindString(2, title);
+            search.bindString(3, pluginData.get(title));
+            search.executeInsert();
+            search.clearBindings();
+        }
+
+        DB.setTransactionSuccessful();
+        DB.endTransaction();
+    }
+
+    Cursor searchQuery(String arg) {
+        String sql = String.format("SELECT %s, %s, %s, %s FROM %s WHERE %s like '%s%%'", COL_ID, SUGGEST_COLUMN_TEXT_1, SUGGEST_COLUMN_QUERY, SUGGEST_COLUMN_INTENT_EXTRA_DATA, TABLE_SEARCH, SUGGEST_COLUMN_TEXT_1, arg);
+        Cursor c = getReadableDatabase().rawQuery(sql, null);
+
+        if (c == null)
+            return null;
+        else if (!c.moveToFirst()) {
+            c.close();
+            return null;
+        }
+        return c;
+    }
+
+    // Return the number of entries in the database
+    int pluginCount() {
+        return (int) DatabaseUtils.queryNumEntries(getReadableDatabase(), TABLE_SEARCH);
+    }
+}

--- a/mobile/src/com/cradle/iitc_mobile/prefs/PluginProvider.java
+++ b/mobile/src/com/cradle/iitc_mobile/prefs/PluginProvider.java
@@ -1,0 +1,60 @@
+package com.cradle.iitc_mobile.prefs;
+
+import android.app.SearchManager;
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.content.UriMatcher;
+import android.database.Cursor;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+
+/**
+ * A ContentProvider used by the search interface in the Plugins preferences to
+ * query the database for plugin names to be presented to the user.
+ */
+public class PluginProvider extends ContentProvider {
+    public static final String AUTHORITY = "com.cradle.iitc_mobile.PluginProvider";
+    private static final int SEARCH_SUGGEST = 0;
+
+    private PluginDatabase db;
+    private UriMatcher matcher;
+
+    @Override
+    public boolean onCreate() {
+        db = new PluginDatabase(getContext());
+        matcher = new UriMatcher(UriMatcher.NO_MATCH);
+        matcher.addURI(AUTHORITY, SearchManager.SUGGEST_URI_PATH_QUERY, SEARCH_SUGGEST);
+        return true;
+    }
+
+    @Override
+    public Cursor query(@NonNull Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        switch(matcher.match(uri)) {
+            case SEARCH_SUGGEST:
+                return db.searchQuery(selectionArgs[0]);
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public String getType(@NonNull Uri uri) {
+        return null;
+    }
+
+    // Required but unused operations for searching
+    @Override
+    public Uri insert(@NonNull Uri uri, ContentValues values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri,  String selection,  String[] selectionArgs) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int update(@NonNull Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
This corresponds to #1228 which suggest making plugins searchable, to be turned on or off more quickly. Here is my implementation, it involves populating a SQLite database which is queried whenever a user types in the search view. It shows the names of all plugins that start with the query which are search suggestions. When a suggestion is tapped, the plugin is toggled as if it's checkbox was clicked and a Toast notifies the user.

The search widget shouldn't interfere with the add script feature already in place. It turns out the activity is not launched in `singleTop` mode so a new activity is created to handle the search, but I handle the suggestion in `onCreate()` and then call `finish()` so the activity animation doesn't occur and there are no other side effects. I made changes to `PluginPreferenceActivity.java`, some are changes to existing methods while others are new methods.