### PR TITLE
Fix Intel Map URL

### DIFF
--- a/build.py
+++ b/build.py
@@ -61,7 +61,7 @@ distUrlBase = settings.get('distUrlBase')
 buildMobile = settings.get('buildMobile')
 antOptions = settings.get('antOptions','')
 antBuildFile = settings.get('antBuildFile', 'mobile/build.xml');
-
+targetHost = settings.get('targetHost') or 'intel.ingress.com'
 
 # plugin wrapper code snippets. handled as macros, to ensure that
 # 1. indentation caused by the "function wrapper()" doesn't apply to the plugin code body
@@ -150,7 +150,7 @@ def extractUserScriptMeta(var):
 
 
 
-def doReplacements(script,updateUrl,downloadUrl,pluginName=None):
+def doReplacements(script,updateUrl,downloadUrl,targetHost,pluginName=None):
 
     script = re.sub('@@INJECTCODE@@',loadCode,script)
 
@@ -175,6 +175,7 @@ def doReplacements(script,updateUrl,downloadUrl,pluginName=None):
 
     script = script.replace('@@UPDATEURL@@', updateUrl)
     script = script.replace('@@DOWNLOADURL@@', downloadUrl)
+    script = script.replace('@@TARGETHOST@@', targetHost)
 
     if (pluginName):
         script = script.replace('@@PLUGINNAME@@', pluginName);
@@ -231,7 +232,7 @@ main = readfile('main.js')
 
 downloadUrl = distUrlBase and distUrlBase + '/total-conversion-build.user.js' or 'none'
 updateUrl = distUrlBase and distUrlBase + '/total-conversion-build.meta.js' or 'none'
-main = doReplacements(main,downloadUrl=downloadUrl,updateUrl=updateUrl)
+main = doReplacements(main, downloadUrl=downloadUrl, updateUrl=updateUrl, targetHost=targetHost)
 
 saveScriptAndMeta(main, outDir, 'total-conversion-build.user.js', oldDir)
 
@@ -248,7 +249,7 @@ for fn in glob.glob("plugins/*.user.js"):
     downloadUrl = distUrlBase and distUrlBase + '/' + fn.replace("\\","/") or 'none'
     updateUrl = distUrlBase and downloadUrl.replace('.user.js', '.meta.js') or 'none'
     pluginName = os.path.splitext(os.path.splitext(os.path.basename(fn))[0])[0]
-    script = doReplacements(script, downloadUrl=downloadUrl, updateUrl=updateUrl, pluginName=pluginName)
+    script = doReplacements(script, downloadUrl=downloadUrl, updateUrl=updateUrl, pluginName=pluginName, targetHost=targetHost)
 
     saveScriptAndMeta(script, outDir, fn, oldDir)
 
@@ -262,7 +263,7 @@ if buildMobile:
     script = readfile("mobile/plugins/" + fn)
     downloadUrl = distUrlBase and distUrlBase + '/' + fn.replace("\\","/") or 'none'
     updateUrl = distUrlBase and downloadUrl.replace('.user.js', '.meta.js') or 'none'
-    script = doReplacements(script, downloadUrl=downloadUrl, updateUrl=updateUrl, pluginName='user-location')
+    script = doReplacements(script, downloadUrl=downloadUrl, updateUrl=updateUrl, pluginName='user-location', targetHost=targetHost)
 
     saveScriptAndMeta(script, outDir, fn)
 

--- a/buildsettings.py
+++ b/buildsettings.py
@@ -16,6 +16,7 @@ buildSettings = {
     'local': {
         'resourceUrlBase': None,
         'distUrlBase': None,
+        'targetHost': 'intel.ingress.com',
     },
 
     # local8000: if you need to modify external resources, this build will load them from
@@ -25,6 +26,7 @@ buildSettings = {
     'local8000': {
         'resourceUrlBase': 'http://0.0.0.0:8000/dist',
         'distUrlBase': None,
+        'targetHost': 'intel.ingress.com',
     },
 
     # mobile: default entry that also builds the mobile .apk
@@ -33,6 +35,7 @@ buildSettings = {
         'resourceUrlBase': None,
         'distUrlBase': None,
         'buildMobile': 'debug',
+        'targetHost': 'intel.ingress.com',
     },
 
 

--- a/main.js
+++ b/main.js
@@ -6,14 +6,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Total conversion for the ingress intel map.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/add-kml.user.js
+++ b/plugins/add-kml.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Allow users to overlay their own KML / GPX files on top of IITC.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/ap-list.user.js
+++ b/plugins/ap-list.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description   PLUGIN CURRENTLY UNAVAILABLE
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/basemap-bing.user.js
+++ b/plugins/basemap-bing.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Add the maps.bing.com map layers.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/basemap-blank.user.js
+++ b/plugins/basemap-blank.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Add a blank map layer - no roads or other features.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/basemap-cloudmade.user.js
+++ b/plugins/basemap-cloudmade.user.js
@@ -5,13 +5,9 @@
 // @version        0.0.0
 // @namespace      https://github.com/jonatkins/ingress-intel-total-conversion
 // @description    Cloudmade no longer offer free accounts for map tiles.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // ==/UserScript==
 

--- a/plugins/basemap-gmaps-gray.user.js
+++ b/plugins/basemap-gmaps-gray.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Add a simplified gray Version of Google map tiles as an optional layer.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/basemap-kartverket.user.js
+++ b/plugins/basemap-kartverket.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Add the color and grayscale map tiles from Kartverket.no as an optional layer.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/basemap-mapquest-open-aerial.user.js
+++ b/plugins/basemap-mapquest-open-aerial.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    MapQuest doesn't support this anymore: https://lists.openstreetmap.org/pipermail/tile-serving/2016-June/003928.html
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/basemap-nokia-ovi.user.js
+++ b/plugins/basemap-nokia-ovi.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Add various map layers from Nokia OVI Maps.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/basemap-opencyclemap.user.js
+++ b/plugins/basemap-opencyclemap.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Add the OpenCycleMap.org map tiles as an optional layer.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/basemap-openstreetmap.user.js
+++ b/plugins/basemap-openstreetmap.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Add the native OpenStreetMap.org map tiles as an optional layer.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/basemap-stamen.user.js
+++ b/plugins/basemap-stamen.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Add the 'Toner' and 'Watercolor' map layers from maps.stamen.com.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/basemap-yandex.user.js
+++ b/plugins/basemap-yandex.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Add Yandex.com (Russian/Русский) map layers
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/bookmarks-by-zaso.user.js
+++ b/plugins/bookmarks-by-zaso.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Save your favorite Maps and Portals and move the intel map with a click. Works with sync.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/cache-details-on-map.user.js
+++ b/plugins/cache-details-on-map.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Cache the details of recently viewed portals and use this to populate the map when possible
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/canvas-render.user.js
+++ b/plugins/canvas-render.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] EXPERIMENTAL: use canvas-based rendering. Can be faster when viewing dense areas. Limited testing of the feature so far
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          unsafeWindow
 // ==/UserScript==
 

--- a/plugins/compute-ap-stats.user.js
+++ b/plugins/compute-ap-stats.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Displays the per-team AP gains available in the current view.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/cross_link.user.js
+++ b/plugins/cross_link.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] EXPERIMENTAL: Checks for existing links that cross planned links. Requires draw-tools plugin.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/debug-raw-portal-data.user.js
+++ b/plugins/debug-raw-portal-data.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Developer debugging aid: Add a link to the portal details to show the raw data of a portal.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/default-intel-detail.user.js
+++ b/plugins/default-intel-detail.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Use the portal level detail levels from the standard intel site. By default, IITC shows less detail when zoomed out, as this is enough for general use, is more friendly to the niantic servers, and loads much faster. This plugin restores the default zoom level to portal level mapping. Note: using this plugin causes a larger number of requests to the intel server, and at high resolutions can cause excessive requests to be made (yes: the default intel site also has this problem!), so it is not recommended except for low resolution screens.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/distance-to-portal.user.js
+++ b/plugins/distance-to-portal.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Allows your current location to be set manually, then shows the distance to the selected portal. Useful when managing portal keys.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/done-links.user.js
+++ b/plugins/done-links.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] A companion to the Cross Links plugin. Highlights any links that match existing draw-tools line/polygon edges
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/draw-resonators.user.js
+++ b/plugins/draw-resonators.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Resonator deployment distance data is no longer available, as of 2014-05-23
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Allow drawing things onto the current map so you may plan your next move.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/favorite-portals.user.js
+++ b/plugins/favorite-portals.user.js
@@ -7,13 +7,9 @@
 // @namespace      https://github.com/jonatkins/ingress-intel-total-conversion
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/fix-googlemap-china-offset.user.js
+++ b/plugins/fix-googlemap-china-offset.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show correct Google Map for China user by applying offset tweaks.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/fly-links.user.js
+++ b/plugins/fly-links.user.js
@@ -6,14 +6,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/force-https.user.js
+++ b/plugins/force-https.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Force https access for the intel map. If the intel map is accessed via http, it redirects to the https version.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/guess-player-levels.user.js
+++ b/plugins/guess-player-levels.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Try to determine player levels from the data available in the current view.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/iitc-ditigal-bumper-sticker.user.js
+++ b/plugins/iitc-ditigal-bumper-sticker.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Adds a "I'd rather be using IITC" logo to the standard intel map.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/ipas-link.user.js
+++ b/plugins/ipas-link.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] No longer available, as the resonator slot number and deployment distance is no longer available
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/keys-on-map.user.js
+++ b/plugins/keys-on-map.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show the manually entered key counts from the 'keys' plugin on the map.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/keys.user.js
+++ b/plugins/keys.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Allow manual entry of key counts for each portal. Use the 'keys-on-map' plugin to show the numbers on the map, and 'sync' to share between multiple browsers or desktop/mobile.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/layer-count.user.js
+++ b/plugins/layer-count.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Allow users to count nested fields
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/layer-farms-find.user.js
+++ b/plugins/layer-farms-find.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Find farms by minimum level.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/link-show-direction.user.js
+++ b/plugins/link-show-direction.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show the direction of links on the map by adding short dashes to the line at the origin portal.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/max-links.user.js
+++ b/plugins/max-links.user.js
@@ -6,14 +6,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Calculate how to link the portals to create a reasonably tidy set of links/fields. Enable from the layer chooser. (Max Links is a poor name, but remains for historical reasons.)
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/minimap.user.js
+++ b/plugins/minimap.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show a mini map on the corner of the map.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/missions.user.js
+++ b/plugins/missions.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] View missions. Marking progress on waypoints/missions basis. Showing mission paths on the map.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/pan-control.user.js
+++ b/plugins/pan-control.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show a panning control on the map.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/periodic-refresh.user.js
+++ b/plugins/periodic-refresh.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    For use for unattended display screens only, this plugin causes idle mode to be left once per hour.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/player-tracker.user.js
+++ b/plugins/player-tracker.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Draw trails for the path a user took onto the map based on status messages in COMMs. Uses up to three hours of data. Does not request chat data on its own, even if that would be useful.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/players-portal-pictures.user.js
+++ b/plugins/players-portal-pictures.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Niantic removed the data this plugin needed. It is no longer possible to search for photo submitter.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/players-resonators.user.js
+++ b/plugins/players-resonators.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    The data this plugin needs is no longer available since the late November 2013 intel site update.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-counts.user.js
+++ b/plugins/portal-counts.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Display a list of all localized portals by level and faction.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portal-defense.user.js
+++ b/plugins/portal-defense.user.js
@@ -7,12 +7,8 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    The data this plugin needs is no longer available since the late November 2013 intel site update.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // ==/UserScript==

--- a/plugins/portal-highlighter-bad-deployment-distance.user.js
+++ b/plugins/portal-highlighter-bad-deployment-distance.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    This plugin is no longer available, as Niantic optimisations have removed the data it needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-highlighter-can-make-level.user.js
+++ b/plugins/portal-highlighter-can-make-level.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    This plugin is no longer available, as Niantic optimisations have removed the data it needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-highlighter-debug.user.js
+++ b/plugins/portal-highlighter-debug.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Various debug and/or temporary highlighters. Will change over time as needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portal-highlighter-forgotten.user.js
+++ b/plugins/portal-highlighter-forgotten.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Use the portal fill color to denote if the portal is unclaimed with no recent activity. Shades of red from one week to one month, then tinted to purple for longer. May also highlight captured portals that are stuck and fail to decay every 24 hours.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portal-highlighter-hide-team.user.js
+++ b/plugins/portal-highlighter-hide-team.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show all portals as neutral, as if uncaptured. Great for creating plans.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portal-highlighter-high-level.user.js
+++ b/plugins/portal-highlighter-high-level.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Use the portal fill color to denote high level portals: Purple L8, Red L7, Orange L6
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portal-highlighter-imminent-decay.user.js
+++ b/plugins/portal-highlighter-imminent-decay.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    This plugin is no longer available, as Niantic optimisations have removed the data it needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-highlighter-infrastructure.user.js
+++ b/plugins/portal-highlighter-infrastructure.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Use the portal fill color to denote if the portal has any infrastructure problems. Red: no picture. Yellow: potential title issue. Orange:  both of these.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portal-highlighter-level-color.user.js
+++ b/plugins/portal-highlighter-level-color.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Use the portal fill color to denote the portal level by using the game level colors.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portal-highlighter-missing-resonators.user.js
+++ b/plugins/portal-highlighter-missing-resonators.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Use the portal fill color to denote if the portal is missing resonators. 
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portal-highlighter-mitigation.user.js
+++ b/plugins/portal-highlighter-mitigation.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    This plugin is no longer available, as Niantic optimisations have removed the data it needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-highlighter-mods.user.js
+++ b/plugins/portal-highlighter-mods.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    This plugin is no longer available, as Niantic optimisations have removed the data it needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-highlighter-my-8-portals.user.js
+++ b/plugins/portal-highlighter-my-8-portals.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    This plugin is no longer available, as Niantic optimisations have removed the data it needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-highlighter-my-portals.user.js
+++ b/plugins/portal-highlighter-my-portals.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    This plugin is no longer available, as Niantic optimisations have removed the data it needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-highlighter-needs-recharge.user.js
+++ b/plugins/portal-highlighter-needs-recharge.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Use the portal fill color to denote if the portal needs recharging and how much. Yellow: above 85%. Orange: above 50%. Red: above 15%. Magenta: below 15%.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portal-highlighter-ornaments.user.js
+++ b/plugins/portal-highlighter-ornaments.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Use the portal fill color to denote portals with additional 'ornament' markers. e.g. Anomaly portals
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portal-highlighter-outbound-link-counter.user.js
+++ b/plugins/portal-highlighter-outbound-link-counter.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description   PLUGIN CURRENTLY UNAVAILABLE
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-highlighter-portal-ap-energy-relative.user.js
+++ b/plugins/portal-highlighter-portal-ap-energy-relative.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    This plugin is no longer available, as Niantic optimisations have removed the data it needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-highlighter-portal-ap-relative.user.js
+++ b/plugins/portal-highlighter-portal-ap-relative.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    This plugin is no longer available, as Niantic optimisations have removed the data it needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-highlighter-portal-ap.user.js
+++ b/plugins/portal-highlighter-portal-ap.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    This plugin is no longer available, as Niantic optimisations have removed the data it needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-highlighter-portals-my-level.user.js
+++ b/plugins/portal-highlighter-portals-my-level.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Use the portal fill color to denote if the portal is either at and above, or at and below your level.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portal-highlighter-portals-upgrade.user.js
+++ b/plugins/portal-highlighter-portals-upgrade.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    This plugin is no longer available, as Niantic optimisations have removed the data it needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-highlighter-with-lvl8-resonators.user.js
+++ b/plugins/portal-highlighter-with-lvl8-resonators.user.js
@@ -7,13 +7,9 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    This plugin is no longer available, as Niantic optimisations have removed the data it needed.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==

--- a/plugins/portal-level-numbers.user.js
+++ b/plugins/portal-level-numbers.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show portal level numbers on map.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portal-names.user.js
+++ b/plugins/portal-names.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show portal names on the map.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/portals-list.user.js
+++ b/plugins/portals-list.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Display a sortable list of all visible portals with full details about the team, resonators, links, etc.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/privacy-view.user.js
+++ b/plugins/privacy-view.user.js
@@ -6,14 +6,10 @@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Hide info from intel which shouldn't leak to players of the other faction.
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/regions.user.js
+++ b/plugins/regions.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show the local scoring regions on the map. No actual scores - just the region areas.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/render-limit-increase.user.js
+++ b/plugins/render-limit-increase.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] IITC no longer has simple render limits that can be adjusted - many more portals are now displayed without any increases required.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/reso-energy-pct-in-portal-detail.user.js
+++ b/plugins/reso-energy-pct-in-portal-detail.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show resonator energy percentage on resonator energy bar in portal detail panel.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/resonator-display-zoom-level-decrease.user.js
+++ b/plugins/resonator-display-zoom-level-decrease.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Resonator display distance is no longer an option set with a plugin. With the 'draw-resonators' plugin you can now turn on/off resonators in the layer chooser instead.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/scale-bar.user.js
+++ b/plugins/scale-bar.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show scale bar on the map.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/score-cycle-times.user.js
+++ b/plugins/score-cycle-times.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show the times used for the septicycle and checkpoints for regional scoreboards.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/scoreboard.user.js
+++ b/plugins/scoreboard.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Display a scoreboard about all visible portals with statistics about both teams,like average portal level,link & field counts etc.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
     

--- a/plugins/scroll-wheel-zoom-disable.user.js
+++ b/plugins/scroll-wheel-zoom-disable.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Disable the use of mouse wheel to zoom. The map zoom controls or keyboard are still available.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/show-address.user.js
+++ b/plugins/show-address.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Address no longer available, as of Niantic changes 2014-05-23
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/show-less-portals-zoomed-out.user.js
+++ b/plugins/show-less-portals-zoomed-out.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Vastly reduce the detail level when zoomed out to level 11 or less (L4+ portals), to significantly reduce data usage when viewing large areas.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/show-linked-portals.user.js
+++ b/plugins/show-linked-portals.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Try to show the linked portals (image, name and link direction) in portal detail view and jump to linked portal on click.  Some details may not be available if the linked portal is not in the current view.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/show-more-portals.user.js
+++ b/plugins/show-more-portals.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Standard intel has changed to show all portals from zoom level 15, which is what this plugin used to force.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/show-portal-weakness.user.js
+++ b/plugins/show-portal-weakness.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Use the fill color of the portals to denote if the portal is weak. Stronger red indicates recharge required, missing resonators, or both.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/speech-search.user.js
+++ b/plugins/speech-search.user.js
@@ -6,14 +6,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Allow speech input for location search (webkit only for now - NOT Firefox).
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/sync.user.js
+++ b/plugins/sync.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Sync data between clients via Google Realtime API. Only syncs data from specific plugins (currently: Keys, Bookmarks). Sign in via the 'Sync' link.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/uniques.user.js
+++ b/plugins/uniques.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Allow manual entry of portals visited/captured. Use the 'highlighter-uniques' plugin to show the uniques on the map, and 'sync' to share between multiple browsers or desktop/mobile. It will try and guess which portals you have captured from COMM/portal details, but this will not catch every case.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/update-check.user.js
+++ b/plugins/update-check.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] **WORK IN PROGRESS** Check for updates for IITC and plugins against http://iitc.jonatkins.com/. Can also report status messages for known IITC issues.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/zaprange.user.js
+++ b/plugins/zaprange.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Shows the maximum range of attack by the portals.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 

--- a/plugins/zoom-slider.user.js
+++ b/plugins/zoom-slider.user.js
@@ -7,14 +7,10 @@
 // @updateURL      @@UPDATEURL@@
 // @downloadURL    @@DOWNLOADURL@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Show a zoom slider on the map instead of the zoom buttons.
-// @include        https://*.ingress.com/intel*
-// @include        http://*.ingress.com/intel*
-// @match          https://*.ingress.com/intel*
-// @match          http://*.ingress.com/intel*
-// @include        https://*.ingress.com/mission/*
-// @include        http://*.ingress.com/mission/*
-// @match          https://*.ingress.com/mission/*
-// @match          http://*.ingress.com/mission/*
+// @include        https://@@TARGETHOST@@/*
+// @include        http://@@TARGETHOST@@/*
+// @match          https://@@TARGETHOST@@/*
+// @match          http://@@TARGETHOST@@/*
 // @grant          none
 // ==/UserScript==
 


### PR DESCRIPTION
Intel Map URL has been changed to [intel.ingress.com](https://intel.ingress.com) from [ingress.com/intel](http://ingress.com/intel).
So I fixed Intel Map URLs.
And I wrote Intel Map URL to `buildsettings.py`.
`@@TARGETHOST@@` will be replaced Intel Map URL when build.

英語に自信がないので日本語を付け加えます。
Intel MapのURLが[ingress.com/intel](http://ingress.com/intel)から[intel.ingress.com](https://intel.ingress.com)に変更されていたので、それに伴って修正をしました。
また、`buildsettings.py`にIntel MapのURLを記述して、ビルド時に`@@TARGETHOST@@`に対して置き換えるようにしました。