### PR TITLE
Add portal histories feature support

### DIFF
--- a/code/entity_decode.js
+++ b/code/entity_decode.js
@@ -77,6 +77,10 @@
 
   var SUMMARY_PORTAL_DATA_LENGTH = 14;
   function summaryPortalData(a) {
+    var VISITED = 1;
+    var CAPTURED = 2;
+    var SCOUT_CONTROLLED = 4;
+    var historyLevel = a[18] || 0;
     return {
       level:         a[4],
       health:        a[5],
@@ -87,11 +91,15 @@
       mission:       a[10],
       mission50plus: a[11],
       artifactBrief: parseArtifactBrief(a[12]),
-      timestamp:     a[13]
+      timestamp:     a[13],
+      visited: (historyLevel & VISITED) === VISITED,
+      captured: (historyLevel & CAPTURED) === CAPTURED,
+      scoutControlled: (historyLevel & SCOUT_CONTROLLED) === SCOUT_CONTROLLED,
     };
   };
 
-  var DETAILED_PORTAL_DATA_LENGTH = SUMMARY_PORTAL_DATA_LENGTH+4;
+  var DETAILED_PORTAL_DATA_LENGTH = SUMMARY_PORTAL_DATA_LENGTH + 4;
+  var WITH_HISTORY_PORTAL_DATA_LENGTH = DETAILED_PORTAL_DATA_LENGTH + 1;
 
 
   window.decodeArray.portalSummary = function(a) {
@@ -105,7 +113,7 @@
 
     // NOTE: allow for either summary or detailed portal data to be passed in here, as details are sometimes
     // passed into code only expecting summaries
-    if (a.length != SUMMARY_PORTAL_DATA_LENGTH && a.length != DETAILED_PORTAL_DATA_LENGTH) {
+    if (![SUMMARY_PORTAL_DATA_LENGTH, DETAILED_PORTAL_DATA_LENGTH, WITH_HISTORY_PORTAL_DATA_LENGTH].includes(a.length)) {
       console.warn('Portal summary length changed - portal details likely broken!');
       debugger;
     }

--- a/code/portal_detail.js
+++ b/code/portal_detail.js
@@ -28,6 +28,19 @@ window.portalDetail.isFresh = function(guid) {
   return cache.isFresh(guid);
 }
 
+// get portal history data (history, captured, scout controlled) from portal summary data cache.
+window.portalDetail.getPortalHistoryData = function (guid) {
+  var portal = window.portals[guid];
+    if (portal == null) {
+      return { // default false
+        visited: false,
+        captured: false,
+        scoutControlled: false,
+      };
+    }
+    var { visited, captured, scoutControlled } = portal.options.data;
+    return { visited, captured, scoutControlled };
+}
 
 var handleResponse = function(guid, data, success) {
   delete requestQueue[guid];
@@ -38,7 +51,10 @@ var handleResponse = function(guid, data, success) {
 
   if (success) {
 
-    var dict = decodeArray.portalDetail(data.result);
+    var dict = {
+      ...decodeArray.portalDetail(data.result),
+      ...window.portalDetail.getPortalHistoryData(guid)
+    };
 
     // entity format, as used in map data
     var ent = [guid,dict.timestamp,data.result];

--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -175,14 +175,6 @@ window.getPortalMiscDetails = function(guid,d) {
 
     var attackValues = getPortalAttackValues(d);
 
-    var { visited, captured, scoutControlled } = window.portals[guid].options.data;
-
-    var historyText = ['history', [
-      ['v', visited],
-      ['c', captured],
-      ['s', scoutControlled]
-    ].filter(([, checked]) => checked).map(([label]) => label).join(',')];
-
     // collect and html-ify random data
 
     var randDetailsData = [
@@ -194,7 +186,6 @@ window.getPortalMiscDetails = function(guid,d) {
       getMitigationText(d,linkCount), getEnergyText(d),
       // and these have some use, even for uncaptured portals
       apGainText, getHackDetailsText(d),
-      historyText
     ];
 
     if(attackValues.attack_frequency != 0)

--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -159,12 +159,10 @@ window.getPortalMiscDetails = function(guid,d) {
 
     var attackValues = getPortalAttackValues(d);
 
-    var { visited, captured, scoutControlled } = window.portals[guid].options.data;
-
     var historyText = ['history', [
-      ['v', visited],
-      ['c', captured],
-      ['s', scoutControlled]
+      ['v', d.visited],
+      ['c', d.captured],
+      ['s', d.scoutControlled]
     ].filter(([, checked]) => checked).map(([label]) => label).join(',')];
 
     // collect and html-ify random data

--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -159,6 +159,13 @@ window.getPortalMiscDetails = function(guid,d) {
 
     var attackValues = getPortalAttackValues(d);
 
+    var { visited, captured, scoutControlled } = window.portals[guid].options.data;
+
+    var historyText = ['history', [
+      ['v', visited],
+      ['c', captured],
+      ['s', scoutControlled]
+    ].filter(([, checked]) => checked).map(([label]) => label).join(',')];
 
     // collect and html-ify random data
 
@@ -171,6 +178,7 @@ window.getPortalMiscDetails = function(guid,d) {
       getMitigationText(d,linkCount), getEnergyText(d),
       // and these have some use, even for uncaptured portals
       apGainText, getHackDetailsText(d),
+      historyText
     ];
 
     if(attackValues.attack_frequency != 0)

--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -32,6 +32,7 @@ window.renderPortalDetails = function(guid) {
   }
 
 
+  var historyData = details ? getPortalHistoryData(details) : '';
   var modDetails = details ? '<div class="mods">'+getModDetails(details)+'</div>' : '';
   var miscDetails = details ? getPortalMiscDetails(guid,details) : '';
   var resoDetails = details ? getResonatorDetails(details) : '';
@@ -96,6 +97,8 @@ window.renderPortalDetails = function(guid) {
     .append(
       $('<h3>').attr({class:'title'}).text(title),
 
+      historyData,
+
       $('<span>').attr({
         class: 'close',
         title: 'Close [w]',
@@ -125,7 +128,20 @@ window.renderPortalDetails = function(guid) {
   }
 }
 
-
+window.getPortalHistoryData = function(d) {
+  return $('<span>')
+    .attr({ style: 'padding-left: 4px'})
+    .text(
+      'history: ' + [
+        ['visited', d.visited],
+        ['captured', d.captured],
+        ['scout controlled', d.scoutControlled]
+      ]
+        .filter(([, checked]) => checked)
+        .map(([label]) => label)
+        .join(', ')
+    );
+}
 
 window.getPortalMiscDetails = function(guid,d) {
 
@@ -159,10 +175,12 @@ window.getPortalMiscDetails = function(guid,d) {
 
     var attackValues = getPortalAttackValues(d);
 
+    var { visited, captured, scoutControlled } = window.portals[guid].options.data;
+
     var historyText = ['history', [
-      ['v', d.visited],
-      ['c', d.captured],
-      ['s', d.scoutControlled]
+      ['v', visited],
+      ['c', captured],
+      ['s', scoutControlled]
     ].filter(([, checked]) => checked).map(([label]) => label).join(',')];
 
     // collect and html-ify random data


### PR DESCRIPTION
related: #1315 

### changes
- Get portal histories (visited, captured, scout controlled) from get entities response.
- Show histories with `renderPortalDetails` function
- Maybe `getPortalDetails` API does not return histories. So store cache with histories from `window.portals[guid]...`

### rendered example

![image](https://user-images.githubusercontent.com/3678413/107657719-c2a84a00-6cc8-11eb-97de-222e23442f7d.png)

