### PR TITLE
applying plugin for url without /intel?

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,8 +8,12 @@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Total conversion for the ingress intel map.
 // @include        https://*.ingress.com/intel*
 // @include        http://*.ingress.com/intel*
+// @include        https://intel.ingress.com/*
+// @include        http://intel.ingress.com/*
 // @match          https://*.ingress.com/intel*
 // @match          http://*.ingress.com/intel*
+// @match          https://intel.ingress.com/*
+// @match          http://intel.ingress.com/*
 // @include        https://*.ingress.com/mission/*
 // @include        http://*.ingress.com/mission/*
 // @match          https://*.ingress.com/mission/*


### PR DESCRIPTION
https://intel.ingress.com/?ll=43.412921,3.696964&z=15&pll=43.412921,3.696964 plugin doesn't start for URL like that because of missing intel between / and ?
fix makes it work